### PR TITLE
feat: Configuración inicial de Docker y Compose (RNF04)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.8'
+
+services:
+  # 1. Servicio del Backend API
+  backend:
+    # 1.1. Ruta y configuración de construcción
+    build: 
+      context: ./newsradar_api
+      dockerfile: Dockerfile
+    # 1.2. Nombre de la imagen
+    image: newsradar_backend_image
+    # 1.3. Nombre del contenedor
+    container_name: newsradar_backend_container
+    # 1.4. Mapeo de puertos para poder acceder desde fuera (Host:Contenedor)
+    ports:
+      - "8000:8000"
+    # 1.5. Variables de entorno
+    environment:
+      - ENVIRONMENT=development
+    # 1.6. Volúmenes: Sincroniza el código local con el del contenedor en tiempo real
+    volumes:
+      - ./newsradar_api/app:/app/app
+    # 1.7. Política de reinicio
+    restart: unless-stopped

--- a/newsradar_api/Dockerfile
+++ b/newsradar_api/Dockerfile
@@ -1,0 +1,20 @@
+# 1. Imagen base de Python
+FROM python:3.11-slim
+
+# 2. Establecemos el directorio de trabajo dentro del contenedor
+WORKDIR /app
+
+# 3. Copiamos el archivo de dependencias (requirements.txt)
+COPY requirements.txt .
+
+# 4. Instalamos los paquetes necesarios
+RUN pip install --no-cache-dir -r requirements.txt
+
+# 5. Copiamos el código fuente de la app a la ruta del contenedor
+COPY ./app ./app
+
+# 6. Exponemos el puerto que usará FastAPI para comunicarse
+EXPOSE 8000
+
+# 7. Ejecutamos el archivo principal (API REST) mediante Uvicorn
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Descripción
Se ha implementado la infraestructura de contenedores solicitada en el requisito **RNF04 (Configuración con Docker)**. Esto estandariza el entorno de desarrollo para todo el equipo y aísla la ejecución del backend.

## Cambios realizados
1. **Creación del `Dockerfile` (Backend):**
   - Implementado en `newsradar_api/` usando la imagen base `python:3.11-slim`.
   - Configuración de la instalación de dependencias (`requirements.txt`).
   - Exposición del puerto `8000` y configuración del arranque con `uvicorn`.

2. **Creación del `docker-compose.yml` (Orquestador):**
   - Implementado en la raíz del proyecto.
   - Definición del servicio `backend` con su construcción (build context).
   - Mapeo de puertos (`8000:8000`) para acceso local.
   - Configuración de volúmenes para habilitar el *hot-reload* (sincronización de código en tiempo real sin necesidad de reconstruir el contenedor).

Closes #5