### PR TITLE
feat(RF04): añadir clasificación IPTC a categorías

### DIFF
--- a/docs/ADRs/ADR-012-clasificacion-iptc.md
+++ b/docs/ADRs/ADR-012-clasificacion-iptc.md
@@ -1,0 +1,23 @@
+# ADR 012: Clasificación IPTC de Categorías de Noticias (RF04)
+**Estado:** Aceptado  
+**Fecha:** 2026-03-30  
+**Autores:** Equipo DevOps-gr84-A  
+## 1. Contexto
+El sistema necesita clasificar las categorías de noticias según estándares periodísticos internacionales para garantizar la interoperabilidad con otras plataformas de medios. Sin un estándar de clasificación común, cada instancia del sistema usaría taxonomías propias, dificultando la integración y el intercambio de contenidos (RNF04). 
+## 2. Alternativas consideradas
+- **Taxonomía propia ad-hoc:** Crear una lista de categorías personalizada. Descartada porque no es interoperable y requiere mantenimiento manual.
+- **NewsML G2 / rNews:** Estándares alternativos del sector. Más complejos de implementar y con menor adopción que IPTC en el contexto europeo.
+- **IPTC Media Topic como catálogo externo obligatorio:** Vincular siempre una categoría a un código IPTC. Descartado para no romper la compatibilidad con categorías ya existentes en el sistema.
+- **IPTC Media Topic como campo opcional con validación:** Permite adopción gradual sin romper el contrato actual de la API. 
+## 3. Decisión
+Se adopta el estándar **IPTC Media Topic** como sistema de clasificación de categorías. Los campos `iptc_code` e `iptc_label` se añaden como campos **opcionales** al modelo `Category`. 
+El catálogo oficial de códigos válidos reside en `app/core/iptc_categories.py` como única fuente de verdad. Cuando se proporciona un `iptc_code` al crear o actualizar una categoría, el sistema valida que pertenezca al catálogo; en caso contrario devuelve HTTP 422. 
+Se expone además el endpoint `GET /api/v1/iptc-categories` para que los clientes puedan consultar el catálogo completo sin necesidad de embeber la lista en el frontend. 
+## 4. Consecuencias
+- **Positivas:**
+  - Las categorías son ahora interoperables con cualquier sistema que entienda IPTC, estándar ampliamente adoptado en la industria periodística.
+  - La validación centralizada en el backend evita que entren códigos inválidos independientemente del cliente que consuma la API.
+  - La opcionalidad de los campos mantiene compatibilidad total con categorías previas y no requiere migración de datos.
+- **Negativas:**
+  - El catálogo IPTC embebido en `iptc_categories.py` es estático; si IPTC actualiza su taxonomía, habrá que actualizar el fichero manualmente.
+  - Los desarrolladores deben conocer el estándar IPTC para asignar códigos correctamente al crear categorías desde el frontend.

--- a/newsradar_api/app/api/routes/categories.py
+++ b/newsradar_api/app/api/routes/categories.py
@@ -1,18 +1,33 @@
 from fastapi import APIRouter, Depends, HTTPException, Response
-from typing import List
+from typing import Annotated, List
 from app.schemas.category import Category, CategoryCreate, CategoryUpdate
 from app.schemas.user import UserInDB
 from app.stores.memory import categories_store, rss_channels_store
 from app.utils.deps import get_current_user
+from app.core.iptc_categories import IPTC_FIRST_LEVEL, VALID_IPTC_CODES
+
 
 categories_router = APIRouter()
 API_PREFIX = "/api/v1"
 
+# Alias para no repetir Annotated en cada función
+CurrentUser = Annotated[UserInDB, Depends(get_current_user)]
+
 
 @categories_router.get(
-    f"{API_PREFIX}/categories", response_model=List[Category], tags=["categories"]
+    f"{API_PREFIX}/iptc-categories",
+    tags=["categories"],
 )
-def list_categories(_: UserInDB = Depends(get_current_user)) -> List[Category]:
+def list_iptc_categories():
+    return [{"code": code, "label": label} for code, label in IPTC_FIRST_LEVEL.items()]
+
+
+@categories_router.get(
+    f"{API_PREFIX}/categories",
+    response_model=List[Category],
+    tags=["categories"],
+)
+def list_categories(_: CurrentUser) -> List[Category]:
     return list(categories_store.values())
 
 
@@ -22,9 +37,9 @@ def list_categories(_: UserInDB = Depends(get_current_user)) -> List[Category]:
     status_code=201,
     tags=["categories"],
 )
-def create_category(
-    payload: CategoryCreate, _: UserInDB = Depends(get_current_user)
-) -> Category:
+def create_category(payload: CategoryCreate, _: CurrentUser) -> Category:
+    if payload.iptc_code is not None and payload.iptc_code not in VALID_IPTC_CODES:
+        raise HTTPException(status_code=422, detail="Código IPTC no válido")
     category_id = max(categories_store.keys(), default=0) + 1
     category = Category(id=category_id, **payload.model_dump())
     categories_store[category_id] = category
@@ -36,7 +51,7 @@ def create_category(
     response_model=Category,
     tags=["categories"],
 )
-def get_category(category_id: int, _: UserInDB = Depends(get_current_user)) -> Category:
+def get_category(category_id: int, _: CurrentUser) -> Category:
     category = categories_store.get(category_id)
     if not category:
         raise HTTPException(status_code=404, detail="Categoría no encontrada")
@@ -49,11 +64,15 @@ def get_category(category_id: int, _: UserInDB = Depends(get_current_user)) -> C
     tags=["categories"],
 )
 def update_category(
-    category_id: int, payload: CategoryUpdate, _: UserInDB = Depends(get_current_user)
+    category_id: int,
+    payload: CategoryUpdate,
+    _: CurrentUser,
 ) -> Category:
     category = categories_store.get(category_id)
     if not category:
         raise HTTPException(status_code=404, detail="Categoría no encontrada")
+    if payload.iptc_code is not None and payload.iptc_code not in VALID_IPTC_CODES:
+        raise HTTPException(status_code=422, detail="Código IPTC no válido")
     updated = category.model_copy(update=payload.model_dump(exclude_unset=True))
     categories_store[category_id] = updated
     return updated
@@ -66,7 +85,7 @@ def update_category(
     response_class=Response,
     tags=["categories"],
 )
-def delete_category(category_id: int, _: UserInDB = Depends(get_current_user)) -> None:
+def delete_category(category_id: int, _: CurrentUser) -> None:
     if category_id not in categories_store:
         raise HTTPException(status_code=404, detail="Categoría no encontrada")
     for channel in rss_channels_store.values():

--- a/newsradar_api/app/api/routes/categories.py
+++ b/newsradar_api/app/api/routes/categories.py
@@ -7,35 +7,26 @@ from app.utils.deps import get_current_user
 from app.core.iptc_categories import IPTC_FIRST_LEVEL, VALID_IPTC_CODES
 
 
-categories_router = APIRouter()
-API_PREFIX = "/api/v1"
+categories_router = APIRouter(prefix="/api/v1")
 
-# Alias para no repetir Annotated en cada función
 CurrentUser = Annotated[UserInDB, Depends(get_current_user)]
 
 
-@categories_router.get(
-    f"{API_PREFIX}/iptc-categories",
-    tags=["categories"],
-)
+@categories_router.get("/iptc-categories", tags=["categories"])
 def list_iptc_categories():
     return [{"code": code, "label": label} for code, label in IPTC_FIRST_LEVEL.items()]
 
 
-@categories_router.get(
-    f"{API_PREFIX}/categories",
-    response_model=List[Category],
-    tags=["categories"],
-)
+@categories_router.get("/categories", tags=["categories"])
 def list_categories(_: CurrentUser) -> List[Category]:
     return list(categories_store.values())
 
 
 @categories_router.post(
-    f"{API_PREFIX}/categories",
-    response_model=Category,
+    "/categories",
     status_code=201,
     tags=["categories"],
+    responses={422: {"description": "Código IPTC no válido"}},
 )
 def create_category(payload: CategoryCreate, _: CurrentUser) -> Category:
     if payload.iptc_code is not None and payload.iptc_code not in VALID_IPTC_CODES:
@@ -46,11 +37,7 @@ def create_category(payload: CategoryCreate, _: CurrentUser) -> Category:
     return category
 
 
-@categories_router.get(
-    f"{API_PREFIX}/categories/{{category_id}}",
-    response_model=Category,
-    tags=["categories"],
-)
+@categories_router.get("/categories/{category_id}", tags=["categories"])
 def get_category(category_id: int, _: CurrentUser) -> Category:
     category = categories_store.get(category_id)
     if not category:
@@ -59,9 +46,9 @@ def get_category(category_id: int, _: CurrentUser) -> Category:
 
 
 @categories_router.put(
-    f"{API_PREFIX}/categories/{{category_id}}",
-    response_model=Category,
+    "/categories/{category_id}",
     tags=["categories"],
+    responses={422: {"description": "Código IPTC no válido"}},
 )
 def update_category(
     category_id: int,
@@ -79,9 +66,9 @@ def update_category(
 
 
 @categories_router.delete(
-    f"{API_PREFIX}/categories/{{category_id}}",
+    "/categories/{category_id}",
     status_code=204,
-    response_model=None,
+    response_model=None, 
     response_class=Response,
     tags=["categories"],
 )

--- a/newsradar_api/app/core/iptc_categories.py
+++ b/newsradar_api/app/core/iptc_categories.py
@@ -1,0 +1,29 @@
+"""
+Categorías de primer nivel del estándar IPTC Media Topics (idioma: es).
+Fuente oficial: https://www.iptc.org/std/NewsCodes/treeview/mediatopic/mediatopic-es.html
+Versión del estándar: 2025-10-10
+Trazabilidad: RF04, RF08, RF13
+"""
+
+IPTC_FIRST_LEVEL: dict[str, str] = {
+    "01000000": "Artes, cultura, entretenimiento y medios",
+    "02000000": "Policía y justicia",
+    "03000000": "Catástrofes y accidentes",
+    "04000000": "Economía, negocios y finanzas",
+    "05000000": "Educación",
+    "06000000": "Medio ambiente",
+    "07000000": "Salud",
+    "08000000": "Interés humano, animales, insólito",
+    "09000000": "Mano de obra",
+    "10000000": "Estilo de vida y tiempo libre",
+    "11000000": "Política",
+    "12000000": "Religión y culto",
+    "13000000": "Ciencia y tecnología",
+    "14000000": "Sociedad",
+    "15000000": "Deporte",
+    "16000000": "Conflicto, guerra y paz",
+    "17000000": "Meteorología",
+}
+
+VALID_IPTC_CODES: frozenset[str] = frozenset(IPTC_FIRST_LEVEL.keys())
+VALID_IPTC_NAMES: frozenset[str] = frozenset(IPTC_FIRST_LEVEL.values())

--- a/newsradar_api/app/schemas/category.py
+++ b/newsradar_api/app/schemas/category.py
@@ -5,6 +5,8 @@ from typing import Optional
 class CategoryBase(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
     source: str = Field(default="IPTC", pattern="^IPTC$")
+    iptc_code: Optional[str] = None
+    iptc_label: Optional[str] = None 
 
 
 class CategoryCreate(CategoryBase):
@@ -14,6 +16,8 @@ class CategoryCreate(CategoryBase):
 class CategoryUpdate(BaseModel):
     name: Optional[str] = Field(None, min_length=1, max_length=120)
     source: Optional[str] = Field(None, pattern="^IPTC$")
+    iptc_code: Optional[str] = None
+    iptc_label: Optional[str] = None 
 
 
 class Category(CategoryBase):

--- a/newsradar_api/tests/unit/test_categories.py
+++ b/newsradar_api/tests/unit/test_categories.py
@@ -1,0 +1,169 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.stores.memory import categories_store
+from app.utils.seed_utils import create_seed_data
+
+
+# Fixture de sesión: ejecuta el seed una sola vez para toda la suite
+@pytest.fixture(scope="session", autouse=True)
+def init_seed():
+    """Equivale al evento on_startup que no se dispara en TestClient directo."""
+    create_seed_data()
+
+
+# Cliente HTTP de pruebas
+@pytest.fixture(scope="session")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# Helper de autenticación
+@pytest.fixture(scope="session")
+def auth_headers(client):
+    response = client.post("/api/v1/auth/login", json={
+        "email": "admin@newsradar.com",
+        "password": "admin123",
+    })
+    assert response.status_code == 200, f"Login fallido: {response.json()}"
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+# IPTC categories
+
+def test_list_iptc_categories_ok(client, auth_headers):
+    response = client.get("/api/v1/iptc-categories", headers=auth_headers)
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    assert len(response.json()) > 0
+
+
+def test_iptc_categories_have_code_and_label(client, auth_headers):
+    response = client.get("/api/v1/iptc-categories", headers=auth_headers)
+    first = response.json()[0]
+    assert "code" in first
+    assert "label" in first
+
+
+# GET /categories
+
+def test_list_categories_requires_auth(client):
+    response = client.get("/api/v1/categories")
+    assert response.status_code == 401
+
+
+def test_list_categories_returns_list(client, auth_headers):
+    response = client.get("/api/v1/categories", headers=auth_headers)
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+
+# POST /categories
+
+def test_create_category_minimal(client, auth_headers):
+    payload = {"name": "Política", "source": "IPTC"}
+    response = client.post("/api/v1/categories", json=payload, headers=auth_headers)
+    assert response.status_code == 201
+    data = response.json()
+    assert data["name"] == "Política"
+    assert data["source"] == "IPTC"
+    assert "id" in data
+
+
+def test_create_category_with_valid_iptc_code(client, auth_headers):
+    iptc_list = client.get("/api/v1/iptc-categories", headers=auth_headers).json()
+    valid_code = iptc_list[0]["code"]
+    valid_label = iptc_list[0]["label"]
+
+    payload = {
+        "name": "Deportes",
+        "source": "IPTC",
+        "iptc_code": valid_code,
+        "iptc_label": valid_label,
+    }
+    response = client.post("/api/v1/categories", json=payload, headers=auth_headers)
+    assert response.status_code == 201
+    assert response.json()["iptc_code"] == valid_code
+    assert response.json()["iptc_label"] == valid_label
+
+
+def test_create_category_with_invalid_iptc_code(client, auth_headers):
+    payload = {
+        "name": "Inválida",
+        "source": "IPTC",
+        "iptc_code": "CODIGO_INEXISTENTE_XYZ",
+    }
+    response = client.post("/api/v1/categories", json=payload, headers=auth_headers)
+    assert response.status_code == 422
+
+
+def test_create_category_without_iptc_code(client, auth_headers):
+    payload = {"name": "Sin IPTC", "source": "IPTC"}
+    response = client.post("/api/v1/categories", json=payload, headers=auth_headers)
+    assert response.status_code == 201
+    assert response.json()["iptc_code"] is None
+
+
+# GET /categories/{id}
+
+def test_get_category_by_id(client, auth_headers):
+    created = client.post("/api/v1/categories", json={"name": "Tech"}, headers=auth_headers)
+    cat_id = created.json()["id"]
+    response = client.get(f"/api/v1/categories/{cat_id}", headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["id"] == cat_id
+
+
+def test_get_category_not_found(client, auth_headers):
+    response = client.get("/api/v1/categories/99999", headers=auth_headers)
+    assert response.status_code == 404
+
+
+#  PUT /categories/{id}
+
+def test_update_category_name(client, auth_headers):
+    created = client.post("/api/v1/categories", json={"name": "Vieja"}, headers=auth_headers)
+    cat_id = created.json()["id"]
+    response = client.put(f"/api/v1/categories/{cat_id}", json={"name": "Nueva"}, headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["name"] == "Nueva"
+
+
+def test_update_category_valid_iptc_code(client, auth_headers):
+    iptc_list = client.get("/api/v1/iptc-categories", headers=auth_headers).json()
+    valid_code = iptc_list[1]["code"]
+    created = client.post("/api/v1/categories", json={"name": "Para actualizar"}, headers=auth_headers)
+    cat_id = created.json()["id"]
+    response = client.put(f"/api/v1/categories/{cat_id}", json={"iptc_code": valid_code}, headers=auth_headers)
+    assert response.status_code == 200
+    assert response.json()["iptc_code"] == valid_code
+
+
+def test_update_category_invalid_iptc_code(client, auth_headers):
+    created = client.post("/api/v1/categories", json={"name": "Para fallar"}, headers=auth_headers)
+    cat_id = created.json()["id"]
+    response = client.put(f"/api/v1/categories/{cat_id}", json={"iptc_code": "MAL_CODIGO"}, headers=auth_headers)
+    assert response.status_code == 422
+
+
+def test_update_category_not_found(client, auth_headers):
+    response = client.put("/api/v1/categories/99999", json={"name": "No existe"}, headers=auth_headers)
+    assert response.status_code == 404
+
+
+# DELETE /categories/{id}
+
+def test_delete_category_ok(client, auth_headers):
+    created = client.post("/api/v1/categories", json={"name": "Para borrar"}, headers=auth_headers)
+    cat_id = created.json()["id"]
+    response = client.delete(f"/api/v1/categories/{cat_id}", headers=auth_headers)
+    assert response.status_code == 204
+    get_response = client.get(f"/api/v1/categories/{cat_id}", headers=auth_headers)
+    assert get_response.status_code == 404
+
+
+def test_delete_category_not_found(client, auth_headers):
+    response = client.delete("/api/v1/categories/99999", headers=auth_headers)
+    assert response.status_code == 404


### PR DESCRIPTION
## Cambios
- Nuevos campos `iptc_code` e `iptc_label` opcionales en `Category`
- Endpoint `GET /api/v1/iptc-categories` con el catálogo IPTC de primer nivel
- Validación de código IPTC en creación y edición de categorías
- Tests unitarios en `tests/unit/test_categories.py` (15 tests)
- Refactorización de `Depends()` a `Annotated` en `categories.py`

Closes #13 