### PR TITLE
ci: implementar despliegue continuo (CD) del frontend en GitHub Pages

### DIFF
--- a/.github/workflows/cd-frontend.yml
+++ b/.github/workflows/cd-frontend.yml
@@ -1,0 +1,56 @@
+name: CD Frontend - Deploy to GitHub Pages
+
+# Trigger: Solo cuando hay push a main Y cambios en newsradar_ui/
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'newsradar_ui/**'
+      - '.github/workflows/cd-frontend.yml'  # Redeploy si cambias este workflow
+  # Permite ejecutar manualmente desde GitHub Actions (opcional)
+  workflow_dispatch:
+
+# Permisos necesarios para GitHub Pages
+permissions:
+  contents: write # Necesario para push a gh-pages
+  id-token: write
+  pages: write
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy Frontend
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Checkout del código
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Setup Node.js
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: 'newsradar_ui/package-lock.json'
+
+      # 3. Instalar dependencias (npm ci es más seguro que npm install en CI)
+      - name: Install dependencies
+        working-directory: newsradar_ui
+        run: npm ci
+
+      # 4. Build del proyecto React
+      - name: Build React app
+        working-directory: newsradar_ui
+        run: npm run build
+
+      # 5. Deploy a GitHub Pages usando peaceiris/actions-gh-pages
+      # (Más robusto para subcarpetas que actions/deploy-pages)
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./newsradar_ui/build
+          cname: ''  # Vacío: usa el dominio default de GitHub Pages
+          force_orphan: true  # Limpia historiales antiguos en gh-pages (opcional)

--- a/newsradar_ui/package.json
+++ b/newsradar_ui/package.json
@@ -2,6 +2,7 @@
   "name": "newsradar_ui",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://DevOpsUC3M-gr84-A.github.io/DevOps-gr84-A",
   "dependencies": {
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",


### PR DESCRIPTION
### 🚀 Objetivo de la PR
Esta Pull Request implementa el **Despliegue Continuo (CD)** para nuestro frontend. A partir de ahora, cada vez que se integre código en la rama `main` que afecte a la carpeta `newsradar_ui`, la aplicación se compilará y se publicará automáticamente en Internet, creando un entorno vivo para el equipo y los profesores.

🛠️ **Decisiones Técnicas y Cambios**
* **Atributo `homepage`:** Se ha añadido la URL de producción en el `package.json` para que React enrute correctamente los *assets* (CSS, JS, imágenes) desde el subdominio de GitHub.
* **Nuevo Workflow (`cd-frontend.yml`):** * Configurado para ejecutarse *solo* si hay cambios en el frontend (`paths: ['newsradar_ui/**']`).
  * Utiliza `npm ci` para garantizar instalaciones limpias y deterministas.
  * Utiliza la action `peaceiris/actions-gh-pages` para publicar la carpeta `build` en la rama huérfana `gh-pages` sin ensuciar el historial de `main`.

⚙️ **Instrucciones post-merge (Para el Admin del repo)**
Una vez aprobada y mergeada esta PR, es necesario ir a:
1. `Settings` > `Pages`
2. En **Source**, seleccionar `Deploy from a branch`.
3. Seleccionar la rama `gh-pages` y la carpeta `/ (root)`.

✅ **Impacto**
Dispondremos de una URL pública siempre actualizada con la última versión estable del frontend, facilitando las pruebas de usabilidad y revisión del Sprint 2.

Closes #26