### PR TITLE
feat(RF17): permisos de lector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
   build-and-test:
     # 3.1.1. Entorno de ejecución (Servidor virtual proporcionado por GitHub)
     runs-on: ubuntu-latest
+    # Se definen variables de entorno necesarias para las pruebas, utilizando secretos para proteger información sensible
+    env:
+      NEWSRADAR_ADMIN_PASSWORD: ${{ secrets.NEWSRADAR_ADMIN_PASSWORD }}
+      NEWSRADAR_LECTOR_PASSWORD: ${{ secrets.NEWSRADAR_LECTOR_PASSWORD }}
 
     # 3.1.2. Secuencia de pasos a ejecutar
     steps:
@@ -57,6 +61,8 @@ jobs:
       - name: Run unit tests (Pytest) with coverage report
         env:
           PYTHONPATH: .
+          NEWSRADAR_ADMIN_PASSWORD: ${{ secrets.NEWSRADAR_ADMIN_PASSWORD }}
+          NEWSRADAR_LECTOR_PASSWORD: ${{ secrets.NEWSRADAR_LECTOR_PASSWORD }}
         run: |
           cd newsradar_api
           pytest tests/unit/ tests/integration/ --cov=app --cov-report=xml --cov-report=html || true

--- a/docs/ADRs/ADR-013-rbac-lector.md
+++ b/docs/ADRs/ADR-013-rbac-lector.md
@@ -1,0 +1,46 @@
+# ADR 013: Control de Acceso Basado en Roles para el rol Lector
+
+## 1. Estado
+
+Aceptado
+
+## 2. Contexto
+
+El requisito **RF17** establece que el rol **Lector** puede acceder a toda la plataforma salvo la gestión de alertas y fuentes. En otras palabras:
+
+- El usuario con rol `Lector` debe poder consultar datos mediante endpoints `GET`.
+- El usuario con rol `Lector` no debe poder crear, modificar ni eliminar alertas ni fuentes.
+
+## 3. Decisión
+
+Se ha decidido implementar RBAC en la capa de dependencias de FastAPI usando una dependencia centralizada que verifica los roles del usuario autenticado.
+
+- Se introduce `get_current_gestor` en `newsradar_api/app/utils/deps.py`.
+- Este dependency permite el acceso solo a usuarios con roles de gestión (`Gestor`, `admin`, `manager`).
+- Se mantiene `get_current_user` para permisos de lectura general.
+
+Se aplica el control de acceso en los endpoints de gestión:
+
+- `newsradar_api/app/api/routes/alerts.py`
+  - `POST /users/{user_id}/alerts`
+  - `PUT /users/{user_id}/alerts/{alert_id}`
+  - `DELETE /users/{user_id}/alerts/{alert_id}`
+- `newsradar_api/app/api/routes/information_sources.py`
+  - `POST /information-sources`
+  - `PUT /information-sources/{source_id}`
+  - `DELETE /information-sources/{source_id}`
+- `newsradar_api/app/api/routes/rss_channels.py`
+  - Se añade la misma restricción a la creación, actualización y borrado de canales RSS vinculados a fuentes.
+
+También se añade un usuario semilla con rol `Lector` y un rol `Gestor` para permitir pruebas funcionales reales.
+
+## 4. Consecuencias
+
+- **Positivas:**
+  - RF17 queda implementado de manera centralizada, manteniendo la lógica de autorización limpia y reutilizable.
+  - El rol `Lector` conserva acceso de solo lectura a las rutas de alertas y fuentes.
+  - Se mejora la seguridad de los endpoints de gestión.
+
+- **Negativas:**
+  - El sistema de roles en memoria conserva la flexibilidad, pero requiere cuidados si se migra a un modelo de base de datos relacional completo.
+  - El cambio de nombres de roles (`Gestor`, `Lector`) puede necesitar sinónimos adicionales si se integran roles heredados con nombres en inglés.

--- a/newsradar_api/app/api/routes/alerts.py
+++ b/newsradar_api/app/api/routes/alerts.py
@@ -3,7 +3,7 @@ from typing import List
 from app.schemas.alert import Alert, AlertCreate, AlertUpdate
 from app.schemas.user import UserInDB
 from app.stores.memory import alerts_store, notifications_store
-from app.utils.deps import get_current_user
+from app.utils.deps import get_current_gestor, get_current_user
 
 
 def ensure_user_exists(user_id: int, users_store):
@@ -35,7 +35,7 @@ def list_user_alerts(
     tags=["alerts"],
 )
 def create_user_alert(
-    user_id: int, payload: AlertCreate, _: UserInDB = Depends(get_current_user)
+    user_id: int, payload: AlertCreate, _: UserInDB = Depends(get_current_gestor)
 ) -> Alert:
     alert_id = max(alerts_store.keys(), default=0) + 1
     alert = Alert(id=alert_id, user_id=user_id, **payload.model_dump())
@@ -68,7 +68,7 @@ def update_user_alert(
     user_id: int,
     alert_id: int,
     payload: AlertUpdate,
-    _: UserInDB = Depends(get_current_user),
+    _: UserInDB = Depends(get_current_gestor),
 ) -> Alert:
     alert = alerts_store.get(alert_id)
     if not alert or alert.user_id != user_id:
@@ -88,7 +88,7 @@ def update_user_alert(
     tags=["alerts"],
 )
 def delete_user_alert(
-    user_id: int, alert_id: int, _: UserInDB = Depends(get_current_user)
+    user_id: int, alert_id: int, _: UserInDB = Depends(get_current_gestor)
 ) -> None:
     alert = alerts_store.get(alert_id)
     if not alert or alert.user_id != user_id:

--- a/newsradar_api/app/api/routes/information_sources.py
+++ b/newsradar_api/app/api/routes/information_sources.py
@@ -7,7 +7,7 @@ from app.schemas.information_sources import (
 )
 from app.schemas.user import UserInDB
 from app.stores.memory import information_sources_store, rss_channels_store
-from app.utils.deps import get_current_user
+from app.utils.deps import get_current_gestor, get_current_user
 
 information_sources_router = APIRouter()
 
@@ -30,7 +30,7 @@ def list_information_sources(
     tags=["information-sources"],
 )
 def create_information_source(
-    payload: InformationSourceCreate, _: UserInDB = Depends(get_current_user)
+    payload: InformationSourceCreate, _: UserInDB = Depends(get_current_gestor)
 ) -> InformationSource:
     source_id = max(information_sources_store.keys(), default=0) + 1
     source = InformationSource(id=source_id, **payload.model_dump())
@@ -62,7 +62,7 @@ def get_information_source(
 def update_information_source(
     source_id: int,
     payload: InformationSourceUpdate,
-    _: UserInDB = Depends(get_current_user),
+    _: UserInDB = Depends(get_current_gestor),
 ) -> InformationSource:
     source = information_sources_store.get(source_id)
     if not source:
@@ -82,7 +82,7 @@ def update_information_source(
     tags=["information-sources"],
 )
 def delete_information_source(
-    source_id: int, _: UserInDB = Depends(get_current_user)
+    source_id: int, _: UserInDB = Depends(get_current_gestor)
 ) -> None:
     if source_id not in information_sources_store:
         raise HTTPException(

--- a/newsradar_api/app/api/routes/rss_channels.py
+++ b/newsradar_api/app/api/routes/rss_channels.py
@@ -14,8 +14,7 @@ from app.schemas.user import UserInDB
 from app.stores.memory import rss_channels_store
 from app.database.database import get_db
 from app.services.rss_service import create_rss_channel, get_all_rss_channels
-from app.api.dependencies import get_current_gestor, get_current_user
-from app.utils.deps import get_current_user
+from app.utils.deps import get_current_gestor, get_current_user
 from app.utils.rss_utils import (
     ensure_information_source_exists,
     ensure_category_exists,
@@ -84,6 +83,7 @@ def list_source_channels(
     response_model=RSSChannel,
     status_code=201,
     tags=["rss-channels"],
+    dependencies=[Depends(get_current_gestor)],
 )
 def create_source_channel(
     source_id: int,
@@ -121,6 +121,7 @@ def get_source_channel(
     "/information-sources/{source_id}/rss-channels/{channel_id}",
     response_model=RSSChannel,
     tags=["rss-channels"],
+    dependencies=[Depends(get_current_gestor)],
 )
 def update_source_channel(
     source_id: int,
@@ -146,6 +147,7 @@ def update_source_channel(
     response_model=None,
     response_class=Response,
     tags=["rss-channels"],
+    dependencies=[Depends(get_current_gestor)],
 )
 def delete_source_channel(
     source_id: int,

--- a/newsradar_api/app/config.py
+++ b/newsradar_api/app/config.py
@@ -1,0 +1,13 @@
+import os
+
+ADMIN_PASSWORD_ENV = "NEWSRADAR_ADMIN_PASSWORD"
+LECTOR_PASSWORD_ENV = "NEWSRADAR_LECTOR_PASSWORD"
+
+admin_password = os.getenv(ADMIN_PASSWORD_ENV)
+lector_password = os.getenv(LECTOR_PASSWORD_ENV)
+
+if admin_password is None or lector_password is None:
+    raise RuntimeError(
+        f"Para inicializar los datos semilla se deben definir las variables de entorno "
+        f"{ADMIN_PASSWORD_ENV} y {LECTOR_PASSWORD_ENV}."
+    )

--- a/newsradar_api/app/utils/deps.py
+++ b/newsradar_api/app/utils/deps.py
@@ -1,9 +1,10 @@
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from app.stores.memory import users_store, active_tokens
+from app.stores.memory import users_store, active_tokens, roles_store
 from app.schemas.user import UserInDB
 
 security = HTTPBearer(auto_error=False)
+MANAGEMENT_ROLE_NAMES = {"Gestor", "admin", "manager"}
 
 
 def get_current_user(
@@ -21,3 +22,20 @@ def get_current_user(
         raise HTTPException(status_code=401, detail="Usuario inválido")
 
     return user
+
+
+def get_user_role_names(user: UserInDB) -> set[str]:
+    return {
+        roles_store[role_id].name
+        for role_id in user.role_ids
+        if role_id in roles_store
+    }
+
+
+def get_current_gestor(current_user: UserInDB = Depends(get_current_user)) -> UserInDB:
+    if not get_user_role_names(current_user).intersection(MANAGEMENT_ROLE_NAMES):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No tienes los permisos necesarios para realizar esta acción.",
+        )
+    return current_user

--- a/newsradar_api/app/utils/seed_utils.py
+++ b/newsradar_api/app/utils/seed_utils.py
@@ -9,10 +9,10 @@ def create_seed_data() -> None:
         return
 
     admin_role_id = next_id("roles")
-    roles_store[admin_role_id] = Role(id=admin_role_id, name="admin")
+    roles_store[admin_role_id] = Role(id=admin_role_id, name="Gestor")
 
-    user_role_id = next_id("roles")
-    roles_store[user_role_id] = Role(id=user_role_id, name="user")
+    lector_role_id = next_id("roles")
+    roles_store[lector_role_id] = Role(id=lector_role_id, name="Lector")
 
     admin_user_id = next_id("users")
     users_store[admin_user_id] = UserInDB(
@@ -23,4 +23,15 @@ def create_seed_data() -> None:
         organization="NewsRadar",
         role_ids=[admin_role_id],
         password="admin123",
+    )
+
+    lector_user_id = next_id("users")
+    users_store[lector_user_id] = UserInDB(
+        id=lector_user_id,
+        email="lector@newsradar.com",
+        first_name="Lector",
+        last_name="NewsRadar",
+        organization="NewsRadar",
+        role_ids=[lector_role_id],
+        password="lector123",
     )

--- a/newsradar_api/app/utils/seed_utils.py
+++ b/newsradar_api/app/utils/seed_utils.py
@@ -1,3 +1,4 @@
+from app.config import admin_password, lector_password
 from app.schemas.roles import Role
 from app.schemas.user import UserInDB
 from app.stores.memory import roles_store, users_store
@@ -22,7 +23,7 @@ def create_seed_data() -> None:
         last_name="NewsRadar",
         organization="NewsRadar",
         role_ids=[admin_role_id],
-        password="admin123",
+        password=admin_password,
     )
 
     lector_user_id = next_id("users")
@@ -33,5 +34,5 @@ def create_seed_data() -> None:
         last_name="NewsRadar",
         organization="NewsRadar",
         role_ids=[lector_role_id],
-        password="lector123",
+        password=lector_password,
     )

--- a/newsradar_api/tests/conftest.py
+++ b/newsradar_api/tests/conftest.py
@@ -18,6 +18,16 @@ if str(newsradar_path) not in sys.path:
     sys.path.insert(0, str(newsradar_path))
 
 
+# 2.2. Inject this path at the very beginning (index 0) of Python's system path.
+# This ensures that statements like 'from app.models import User' resolve correctly.
+if str(newsradar_path) not in sys.path:
+    sys.path.insert(0, str(newsradar_path))
+
+# 2.3. Establecer contraseñas de entorno de prueba para evitar hard-coded credentials
+os.environ.setdefault("NEWSRADAR_ADMIN_PASSWORD", "admin123")
+os.environ.setdefault("NEWSRADAR_LECTOR_PASSWORD", "lector123")
+
+
 # 3. Shared Test Fixtures
 # The @pytest.fixture decorator creates reusable pieces of data or configurations
 # that can be injected into any test simply by adding the function name as a parameter.

--- a/newsradar_api/tests/unit/test_rbac.py
+++ b/newsradar_api/tests/unit/test_rbac.py
@@ -1,0 +1,101 @@
+import pytest
+from fastapi.testclient import TestClient
+from app.main import app
+from app.utils.seed_utils import create_seed_data
+
+
+@pytest.fixture(scope="session", autouse=True)
+def init_seed():
+    """Equivale al evento on_startup que no se dispara en TestClient directo."""
+    create_seed_data()
+
+
+@pytest.fixture(scope="session")
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture(scope="session")
+def admin_auth_headers(client):
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "admin@newsradar.com", "password": "admin123"},
+    )
+    assert response.status_code == 200, response.text
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="session")
+def lector_auth_headers(client):
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "lector@newsradar.com", "password": "lector123"},
+    )
+    assert response.status_code == 200, response.text
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(scope="session")
+def sample_information_source(client, admin_auth_headers):
+    response = client.post(
+        "/api/v1/information-sources",
+        json={"name": "Agencia EFE", "url": "https://www.efe.com/rss.xml"},
+        headers=admin_auth_headers,
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+def test_lector_can_read_alerts_and_sources(client, lector_auth_headers, sample_information_source):
+    list_response = client.get("/api/v1/information-sources", headers=lector_auth_headers)
+    assert list_response.status_code == 200
+    assert any(source["id"] == sample_information_source for source in list_response.json())
+
+    get_source_response = client.get(
+        f"/api/v1/information-sources/{sample_information_source}",
+        headers=lector_auth_headers,
+    )
+    assert get_source_response.status_code == 200
+
+    get_alerts_response = client.get("/api/v1/users/2/alerts", headers=lector_auth_headers)
+    assert get_alerts_response.status_code == 200
+    assert isinstance(get_alerts_response.json(), list)
+
+
+def test_lector_cannot_create_alert(client, lector_auth_headers):
+    response = client.post(
+        "/api/v1/users/2/alerts",
+        json={
+            "name": "Alerta de prueba",
+            "descriptors": ["economía"],
+            "categories": [],
+            "cron_expression": "0 0 * * *",
+        },
+        headers=lector_auth_headers,
+    )
+    assert response.status_code == 403
+
+
+def test_lector_cannot_manage_information_sources(client, lector_auth_headers, sample_information_source):
+    create_response = client.post(
+        "/api/v1/information-sources",
+        json={"name": "Fuente secreta", "url": "https://ejemplo.com/rss.xml"},
+        headers=lector_auth_headers,
+    )
+    assert create_response.status_code == 403
+
+    update_response = client.put(
+        f"/api/v1/information-sources/{sample_information_source}",
+        json={"name": "Fuente modificada"},
+        headers=lector_auth_headers,
+    )
+    assert update_response.status_code == 403
+
+    delete_response = client.delete(
+        f"/api/v1/information-sources/{sample_information_source}",
+        headers=lector_auth_headers,
+    )
+    assert delete_response.status_code == 403


### PR DESCRIPTION
### Descripción
Esta PR completa la implementación del control de acceso basado en roles (RBAC) con foco en el rol **Lector**, asegurando que solo tenga permisos de lectura.

Incluye lógica en backend, validación mediante tests y documentación de la decisión arquitectónica.

---

### Cambios principales

#### Backend
- Se añade la dependencia `get_current_gestor` para restringir operaciones de gestión
- Se limita la **creación, actualización y eliminación** de:
  - Alertas
  - Fuentes
  - Canales RSS (`rss_channels.py`)
- Se añaden seeds iniciales de roles:
  - `Gestor`
  - `Lector`

#### Tests
- Se añade `newsradar_api/tests/unit/test_rbac.py`
- Se valida que el rol **Lector**:
  -  Puede consultar recursos
  -  No puede gestionar (crear/editar/eliminar) alertas ni fuentes

#### Documentación
- Se añade el ADR:
  - `docs/ADRs/ADR-013-rbac-lector.md`
- Se documenta la restricción de permisos del rol Lector

---

###  Resultado
- Acceso de solo lectura garantizado para el rol **Lector**
- Restricciones aplicadas correctamente en backend
- Cobertura mediante tests automatizados
- Decisión documentada en ADR
 



Closes #33 