### PR TITLE
feat(RF18): recuperación de contraseña mediante token de un solo uso

### DIFF
--- a/docs/ADRs/ADR-019-recuperacion-contrasena.md
+++ b/docs/ADRs/ADR-019-recuperacion-contrasena.md
@@ -1,0 +1,111 @@
+# ADR 019: Recuperación de Contraseña mediante Token de Un Solo Uso
+
+**Estado:** Aceptado  
+**Fecha:** 2026-04-18  
+**Autores:** Equipo DevOps-gr84-A  
+**Issue relacionado:** [RF18 #34](https://github.com/DevOpsUC3M-gr84-A/DevOps-gr84-A/issues/34)
+
+---
+
+## 1. Contexto
+
+El requisito **RF18** establece que un usuario debe poder recuperar su contraseña si no la recuerda. Esta funcionalidad es crítica para la usabilidad de la plataforma y debe diseñarse de forma segura para evitar ataques de enumeración de usuarios y reutilización de tokens.
+
+---
+
+## 2. Alternativas consideradas
+
+| Alternativa | Descripción | Descartada por |
+|---|---|---|
+| **Token JWT de corta duración** | Emitir un JWT firmado con tiempo de expiración embebido | Requiere clave secreta adicional; el token no se puede invalidar antes de su expiración sin una lista negra |
+| **Token aleatorio en BD (elegida)** | Generar un token `secrets.token_urlsafe(32)` y persistirlo en la fila del usuario junto con su fecha de expiración | — |
+| **Enlace de sesión temporal (magic link)** | Crear una sesión de un solo uso sin contraseña intermedia | Complejidad extra innecesaria para el alcance del proyecto |
+| **Preguntas de seguridad** | Responder preguntas personales para cambiar la contraseña | Práctica obsoleta y con mala experiencia de usuario |
+
+---
+
+## 3. Decisión
+
+Se implementa el flujo estándar de recuperación de contraseña en dos pasos:
+
+### Flujo
+
+```
+Usuario → POST /api/v1/auth/forgot-password  →  genera token → email
+Usuario → POST /api/v1/auth/reset-password   →  valida token → nueva contraseña
+```
+
+### Componentes modificados
+
+**`app/models/user.py`**  
+Se añaden dos columnas al modelo `User`:
+- `reset_password_token` (`String`, nullable, indexado) — almacena el token generado.
+- `reset_password_token_expires` (`DateTime(timezone=True)`, nullable) — fecha de expiración.
+
+**`app/schemas/auth.py`**  
+Se añaden tres schemas Pydantic:
+- `ForgotPasswordRequest` — valida el campo `email`.
+- `ResetPasswordRequest` — valida `token` (no vacío) y `new_password` (6–128 chars).
+- `MessageResponse` — respuesta genérica con campo `message`.
+
+**`app/services/user_service.py`**  
+Se añaden dos funciones de servicio:
+- `generate_reset_token(db, email)` — busca al usuario, genera un token con `secrets.token_urlsafe(32)`, calcula la expiración según `RESET_TOKEN_EXPIRE_HOURS` y persiste ambos valores.
+- `reset_password_with_token(db, token, new_password)` — valida el token, comprueba la expiración (con normalización de timezone para compatibilidad con SQLite), actualiza el hash de la contraseña e invalida el token.
+
+**`app/api/routes/auth.py`**  
+Se añaden dos endpoints públicos (sin autenticación requerida):
+- `POST /api/v1/auth/forgot-password` — devuelve siempre `HTTP 202` para evitar enumeración de usuarios.
+- `POST /api/v1/auth/reset-password` — devuelve `HTTP 200` si el token es válido o `HTTP 400` si es inválido/expirado.
+
+**`app/utils/email_utils.py`**  
+Se añade `send_reset_password_email(to_email, reset_token)` que construye el enlace `{FRONTEND_URL}/reset-password?token=<TOKEN>` y lo envía en formato texto plano y HTML. En entornos sin SMTP configurado (`SMTP_USER` vacío), registra el enlace en el log en lugar de fallar.
+
+**`app/config.py`**  
+Se añaden variables de entorno:
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_FROM`
+- `FRONTEND_URL` — URL base del frontend para construir el enlace de reset.
+- `RESET_TOKEN_EXPIRE_HOURS` — tiempo de validez del token (por defecto: 1 hora).
+
+---
+
+## 4. Decisiones de seguridad explícitas
+
+- **Anti-enumeración:** `POST /auth/forgot-password` devuelve siempre `HTTP 202` con el mismo mensaje, sin revelar si el email está o no registrado.
+- **Token de un solo uso:** una vez utilizado correctamente, el token y su fecha de expiración se ponen a `NULL` en la BD, impidiendo su reutilización.
+- **Expiración:** el token expira en `RESET_TOKEN_EXPIRE_HOURS` horas (1h por defecto). Al expirar, se limpia de la BD.
+- **Hash de contraseña:** la nueva contraseña se hashea con Argon2 (vía Passlib), igual que en el registro.
+- **Normalización de timezone:** se maneja el caso de BD SQLite que devuelve `datetime` sin `tzinfo` para evitar errores de comparación.
+
+---
+
+## 5. Consecuencias
+
+**Positivas:**
+- RF18 queda completamente implementado con un flujo seguro y estándar en la industria.
+- El diseño es compatible con el modelo `User` ya existente sin migraciones complejas.
+- La función `send_reset_password_email` es tolerante a fallos: un error SMTP no interrumpe el flujo ni revela información al cliente.
+- La lógica está completamente testeada con 20 tests unitarios que cubren todos los caminos de código.
+
+**Negativas:**
+- El token se almacena en texto claro en la BD. Una mitigación futura sería almacenar su hash (como hace Django), aunque para el alcance actual es aceptable.
+- El modelo `User` acumula responsabilidades de autenticación y recuperación. En una evolución futura se podría extraer a una tabla `PasswordResetToken` independiente.
+- Requiere configuración SMTP correcta en producción; sin ella, el flujo funciona en modo desarrollo (log del enlace) pero no envía correos reales.
+
+---
+
+## 6. Referencias cruzadas
+
+| Elemento | Referencia |
+|---|---|
+| Requisito | RF18 — Issue #34 |
+| Issue frontend relacionado | RF18-Frontend — Issue #80 |
+| Modelo de datos | `newsradar_api/app/models/user.py` |
+| Schemas | `newsradar_api/app/schemas/auth.py` |
+| Servicio | `newsradar_api/app/services/user_service.py` |
+| Endpoints | `newsradar_api/app/api/routes/auth.py` |
+| Email | `newsradar_api/app/utils/email_utils.py` |
+| Configuración | `newsradar_api/app/config.py` |
+| Tests | `newsradar_api/tests/unit/test_rf18_password_recovery.py` |
+| ADR arquitectura API | ADR-006 |
+| ADR gestión usuarios | ADR-006 |

--- a/newsradar_api/app/api/routes/auth.py
+++ b/newsradar_api/app/api/routes/auth.py
@@ -1,6 +1,5 @@
 from uuid import uuid4
-from typing import Annotated
-from typing import List
+from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -8,13 +7,22 @@ from sqlalchemy.orm import Session
 from app.database.database import get_db
 from app.models.user import User as DBUser
 from app.schemas.user import UserCreate, User, UserInDB
-from app.schemas.auth import LoginRequest, TokenResponse
+from app.schemas.auth import (
+    LoginRequest,
+    TokenResponse,
+    ForgotPasswordRequest,
+    ResetPasswordRequest,
+    MessageResponse,
+)
 from app.stores.memory import users_store, active_tokens
 from app.services.user_service import role_ids_from_role
 from app.utils.user_utils import ensure_role_ids_exist, sync_memory_user, to_user_schema
+from app.utils.email_utils import send_reset_password_email
 from app.services.user_service import (
     create_db_user,
     verify_password,
+    generate_reset_token,
+    reset_password_with_token,
 )
 
 
@@ -79,3 +87,51 @@ def register(payload: UserCreate, db: Annotated[Session, Depends(get_db)]) -> Us
 
     sync_memory_user(user_db)
     return to_user_schema(user_db)
+
+# Recuperación de contraseña
+
+@api_auth_router.post(
+    "/auth/forgot-password",
+    tags=["auth"],
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Solicitar recuperación de contraseña",
+    description=(
+        "Recibe un email y, si existe en el sistema, envía un enlace de reset. "
+        "Siempre devuelve 202 para no revelar si el email está registrado."
+    ),
+)
+def forgot_password(
+    payload: ForgotPasswordRequest,
+    db: Annotated[Session, Depends(get_db)],
+) -> MessageResponse:
+    token = generate_reset_token(db, payload.email)
+
+    # Si el usuario existe, enviamos el email (el fallo de envío se loguea internamente)
+    if token is not None:
+        send_reset_password_email(to_email=payload.email, reset_token=token)
+
+    # Respuesta siempre igual (evita enumeración de usuarios)
+    return MessageResponse(
+        message="Si el email está registrado, recibirás un enlace de recuperación en breve."
+    )
+
+
+@api_auth_router.post(
+    "/auth/reset-password",
+    tags=["auth"],
+    summary="Restablecer contraseña con token",
+    description="Valida el token recibido por email y establece la nueva contraseña.",
+    responses={
+        400: {"description": "Token inválido o expirado"},
+    },
+)
+def reset_password(
+    payload: ResetPasswordRequest,
+    db: Annotated[Session, Depends(get_db)],
+) -> MessageResponse:
+    success, message = reset_password_with_token(db, payload.token, payload.new_password)
+
+    if not success:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message)
+
+    return MessageResponse(message=message)

--- a/newsradar_api/app/config.py
+++ b/newsradar_api/app/config.py
@@ -13,3 +13,17 @@ if admin_password is None or lector_password is None:
         f"Para inicializar los datos semilla se deben definir las variables de entorno "
         f"{ADMIN_PASSWORD_ENV} y {LECTOR_PASSWORD_ENV}."
     )
+
+
+# SMTP (recuperación de contraseña)
+SMTP_HOST: str = os.getenv("SMTP_HOST", "smtp.gmail.com")
+SMTP_PORT: int = int(os.getenv("SMTP_PORT", "587"))
+SMTP_USER: str = os.getenv("SMTP_USER", "")
+SMTP_PASSWORD: str = os.getenv("SMTP_PASSWORD", "")
+SMTP_FROM: str = os.getenv("SMTP_FROM", SMTP_USER)
+
+# URL base del frontend (para construir el link del email)
+FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:3000")
+
+# Tiempo de expiración del token de reset (en horas)
+RESET_TOKEN_EXPIRE_HOURS: int = int(os.getenv("RESET_TOKEN_EXPIRE_HOURS", "1"))

--- a/newsradar_api/app/models/user.py
+++ b/newsradar_api/app/models/user.py
@@ -33,3 +33,7 @@ class User(Base):
 
     # Fecha de control para calcular la caducidad de 24 horas
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    # Recuperación de contraseña
+    reset_password_token = Column(String, nullable=True, index=True)
+    reset_password_token_expires = Column(DateTime(timezone=True), nullable=True)

--- a/newsradar_api/app/schemas/auth.py
+++ b/newsradar_api/app/schemas/auth.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field
 
 
 class LoginRequest(BaseModel):
@@ -11,3 +11,20 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
     user_id: int
     role_ids: list[int]
+
+#  Recuperación de contraseña
+
+class ForgotPasswordRequest(BaseModel):
+    """Payload para solicitar el enlace de recuperación de contraseña."""
+    email: EmailStr
+
+
+class ResetPasswordRequest(BaseModel):
+    """Payload para establecer la nueva contraseña usando el token recibido por email."""
+    token: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=6, max_length=128)
+
+
+class MessageResponse(BaseModel):
+    """Respuesta genérica con un mensaje informativo."""
+    message: str

--- a/newsradar_api/app/services/user_service.py
+++ b/newsradar_api/app/services/user_service.py
@@ -1,10 +1,12 @@
 """Este módulo contiene funciones relacionadas con la lógica de verificación de usuarios"""
 
+import secrets
 from datetime import datetime, timedelta, timezone
 from passlib.context import CryptContext
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from app import config
 from app.models.user import User, UserRole
 from app.schemas.user import UserCreate, UserUpdate
 
@@ -130,3 +132,57 @@ def update_user_role(db: Session, user_id: int, new_role: UserRole) -> bool:
     db.commit()
     db.refresh(user)
     return True
+
+# Recuperación de contraseña
+
+def generate_reset_token(db: Session, email: str) -> str | None:
+    """
+    Genera un token seguro de reset para el usuario con ese email y lo persiste en BD.
+
+    Devuelve el token si el usuario existe, None si no (el caller no debe revelar
+    esta diferencia al cliente para evitar enumeración de usuarios).
+    """
+    user = db.query(User).filter(User.email == email).first()
+    if user is None:
+        return None
+
+    token = secrets.token_urlsafe(32)
+    expires = datetime.now(timezone.utc) + timedelta(hours=config.RESET_TOKEN_EXPIRE_HOURS)
+
+    user.reset_password_token = token
+    user.reset_password_token_expires = expires
+    db.commit()
+    return token
+
+
+def reset_password_with_token(db: Session, token: str, new_password: str) -> tuple[bool, str]:
+    """
+    Valida el token de reset y actualiza la contraseña si es válido y no ha expirado.
+
+    Devuelve (True, mensaje_ok) o (False, mensaje_error).
+    """
+    user = db.query(User).filter(User.reset_password_token == token).first()
+
+    if user is None:
+        return False, "Token inválido o ya utilizado."
+
+    now = datetime.now(timezone.utc)
+    expires = user.reset_password_token_expires
+
+    # Normalizar zona horaria si la BD devuelve datetime naive
+    if expires is not None and expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+
+    if expires is None or now > expires:
+        # Limpiar token expirado
+        user.reset_password_token = None
+        user.reset_password_token_expires = None
+        db.commit()
+        return False, "El enlace de recuperación ha expirado. Solicita uno nuevo."
+
+    # Token válido: actualizar contraseña e invalidar token
+    user.hashed_password = get_password_hash(new_password)
+    user.reset_password_token = None
+    user.reset_password_token_expires = None
+    db.commit()
+    return True, "Contraseña actualizada correctamente."

--- a/newsradar_api/app/utils/email_utils.py
+++ b/newsradar_api/app/utils/email_utils.py
@@ -1,0 +1,80 @@
+"""Utilidad para el envío de correos electrónicos via SMTP (stdlib, sin deps extra)."""
+
+import logging
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from app import config
+
+logger = logging.getLogger("uvicorn.error")
+
+
+def send_reset_password_email(to_email: str, reset_token: str) -> None:
+    """
+    Envía el correo de recuperación de contraseña con el enlace de reset.
+
+    El enlace apunta a FRONTEND_URL/reset-password?token=<TOKEN>.
+    Si SMTP_USER está vacío (entorno de test/dev), solo loguea el enlace
+    sin intentar la conexión SMTP real.
+    """
+    reset_link = f"{config.FRONTEND_URL}/reset-password?token={reset_token}"
+
+    # Modo desarrollo: sin SMTP configurado
+    if not config.SMTP_USER:
+        logger.warning(
+            "[RF18][DEV] SMTP no configurado. Enlace de reset generado: %s",
+            reset_link,
+        )
+        return
+
+    # Construcción del mensaje
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "NewsRadar – Recuperación de contraseña"
+    msg["From"] = config.SMTP_FROM
+    msg["To"] = to_email
+
+    text_body = (
+        f"Has solicitado recuperar tu contraseña en NewsRadar.\n\n"
+        f"Accede al siguiente enlace para establecer una nueva contraseña "
+        f"(válido durante {config.RESET_TOKEN_EXPIRE_HOURS} hora/s):\n\n"
+        f"{reset_link}\n\n"
+        f"Si no has solicitado este cambio, ignora este correo."
+    )
+
+    html_body = f"""
+    <html>
+      <body style="font-family: Arial, sans-serif; color: #28251d; max-width: 520px; margin: auto;">
+        <h2 style="color: #01696f;">NewsRadar – Recuperación de contraseña</h2>
+        <p>Has solicitado recuperar tu contraseña.</p>
+        <p>Haz clic en el botón para establecer una nueva contraseña.
+           El enlace es válido durante <strong>{config.RESET_TOKEN_EXPIRE_HOURS} hora(s)</strong>.</p>
+        <p style="text-align:center; margin: 32px 0;">
+          <a href="{reset_link}"
+             style="background:#01696f;color:#fff;padding:12px 28px;
+                    border-radius:6px;text-decoration:none;font-weight:bold;">
+            Restablecer contraseña
+          </a>
+        </p>
+        <p style="color:#7a7974; font-size:13px;">
+          Si no has solicitado este cambio, ignora este correo.<br>
+          El enlace expirará automáticamente.
+        </p>
+      </body>
+    </html>
+    """
+
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    # Envío con STARTTLS
+    try:
+        with smtplib.SMTP(config.SMTP_HOST, config.SMTP_PORT, timeout=10) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(config.SMTP_USER, config.SMTP_PASSWORD)
+            server.sendmail(config.SMTP_FROM, to_email, msg.as_string())
+        logger.info("[RF18] Email de reset enviado a %s", to_email)
+    except smtplib.SMTPException as exc:
+        # No propagamos el error: el usuario no debe saber si el email existe
+        logger.error("[RF18] Fallo al enviar email de reset a %s: %s", to_email, exc)

--- a/newsradar_api/tests/unit/test_recup_contr.py
+++ b/newsradar_api/tests/unit/test_recup_contr.py
@@ -348,3 +348,120 @@ class TestResetPasswordEndpoint:
         )
 
         assert resp.status_code == 422
+    # ── send_reset_password_email ─────────────────────────────────────────────────
+
+@pytest.mark.unit
+class TestSendResetPasswordEmail:
+
+    def test_dev_mode_logs_and_does_not_send_when_smtp_not_configured(self, caplog):
+        """Sin SMTP configurado solo loguea el enlace, no intenta conexion."""
+        from app.utils.email_utils import send_reset_password_email
+        from app.utils import email_utils as eu_module
+        import logging
+
+        original = eu_module.config.SMTP_USER
+        eu_module.config.SMTP_USER = ""
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="uvicorn.error"):
+                send_reset_password_email("user@test.com", "tok_dev")
+            assert any("tok_dev" in r.message for r in caplog.records)
+        finally:
+            eu_module.config.SMTP_USER = original
+
+    def test_dev_mode_does_not_raise(self):
+        """Sin SMTP configurado la funcion no lanza excepcion."""
+        from app.utils.email_utils import send_reset_password_email
+        from app.utils import email_utils as eu_module
+
+        original = eu_module.config.SMTP_USER
+        eu_module.config.SMTP_USER = ""
+
+        try:
+            send_reset_password_email("user@test.com", "tok_noerror")
+        finally:
+            eu_module.config.SMTP_USER = original
+
+    def test_smtp_send_called_when_configured(self):
+        """Con SMTP configurado llama a smtplib.SMTP y envia el mensaje."""
+        from app.utils.email_utils import send_reset_password_email
+        from app.utils import email_utils as eu_module
+
+        eu_module.config.SMTP_USER = "sender@test.com"
+        eu_module.config.SMTP_PASSWORD = "secret"
+        eu_module.config.SMTP_HOST = "smtp.test.com"
+        eu_module.config.SMTP_PORT = 587
+        eu_module.config.SMTP_FROM = "sender@test.com"
+        eu_module.config.FRONTEND_URL = "http://localhost:3000"
+
+        try:
+            with patch("app.utils.email_utils.smtplib.SMTP") as mock_smtp:
+                instance = mock_smtp.return_value.__enter__.return_value
+                send_reset_password_email("dest@test.com", "tok_smtp")
+
+            mock_smtp.assert_called_once_with("smtp.test.com", 587, timeout=10)
+            instance.starttls.assert_called_once()
+            instance.login.assert_called_once_with("sender@test.com", "secret")
+            instance.sendmail.assert_called_once()
+        finally:
+            eu_module.config.SMTP_USER = ""
+
+    def test_smtp_exception_is_caught_and_does_not_propagate(self):
+        """Un fallo SMTP no debe propagar la excepcion al caller."""
+        from app.utils.email_utils import send_reset_password_email
+        from app.utils import email_utils as eu_module
+        import smtplib
+
+        eu_module.config.SMTP_USER = "sender@test.com"
+        eu_module.config.SMTP_PASSWORD = "secret"
+        eu_module.config.SMTP_HOST = "smtp.test.com"
+        eu_module.config.SMTP_PORT = 587
+        eu_module.config.SMTP_FROM = "sender@test.com"
+        eu_module.config.FRONTEND_URL = "http://localhost:3000"
+
+        try:
+            with patch(
+                "app.utils.email_utils.smtplib.SMTP",
+                side_effect=smtplib.SMTPException("fallo de red"),
+            ):
+                send_reset_password_email("dest@test.com", "tok_fail")
+            # Si llegamos aqui, la excepcion fue capturada correctamente
+        finally:
+            eu_module.config.SMTP_USER = ""
+
+    def test_reset_link_contains_token_and_frontend_url(self):
+        """El enlace generado incluye el token y la FRONTEND_URL correctamente."""
+        import base64
+        from app.utils.email_utils import send_reset_password_email
+        from app.utils import email_utils as eu_module
+
+        eu_module.config.SMTP_USER = "sender@test.com"
+        eu_module.config.SMTP_PASSWORD = "secret"
+        eu_module.config.SMTP_HOST = "smtp.test.com"
+        eu_module.config.SMTP_PORT = 587
+        eu_module.config.SMTP_FROM = "sender@test.com"
+        eu_module.config.FRONTEND_URL = "http://mifrontend.com"
+
+        try:
+            with patch("app.utils.email_utils.smtplib.SMTP") as mock_smtp:
+                instance = mock_smtp.return_value.__enter__.return_value
+                send_reset_password_email("dest@test.com", "tok_url_check")
+
+            raw_email = instance.sendmail.call_args[0][2]
+
+            # Decodificar solo los bloques base64 validos (longitud multiplo de 4)
+            decoded_parts = []
+            for part in raw_email.split("\n"):
+                part = part.strip()
+                if len(part) >= 20 and len(part) % 4 == 0:
+                    try:
+                        decoded_parts.append(
+                            base64.b64decode(part).decode("utf-8", errors="ignore")
+                        )
+                    except Exception:
+                        pass
+
+            decoded = " ".join(decoded_parts)
+            assert "http://mifrontend.com/reset-password?token=tok_url_check" in decoded.replace(" ", "")
+        finally:
+            eu_module.config.SMTP_USER = ""

--- a/newsradar_api/tests/unit/test_recup_contr.py
+++ b/newsradar_api/tests/unit/test_recup_contr.py
@@ -1,0 +1,350 @@
+"""
+Tests unitarios para Recuperación de contraseña.
+
+Cubre:
+  - generate_reset_token  (user_service)
+  - reset_password_with_token (user_service)
+  - POST /auth/forgot-password (auth route)
+  - POST /auth/reset-password (auth route)
+
+Ejecutar con:
+    pytest tests/unit/test_recup_contr.py -v
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# Helper 
+
+def _make_user(
+    *,
+    email="test@example.com",
+    reset_token=None,
+    token_expires=None,
+    hashed_password="hashed_old",
+):
+    user = MagicMock()
+    user.email = email
+    user.reset_password_token = reset_token
+    user.reset_password_token_expires = token_expires
+    user.hashed_password = hashed_password
+    return user
+
+
+def _get_client():
+    """Crea un TestClient mínimo que sólo registra el router de autenticación."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from app.api.routes.auth import api_auth_router
+
+    app = FastAPI()
+    app.include_router(api_auth_router)
+    return TestClient(app)
+
+
+# generate_reset_token
+
+@pytest.mark.unit
+class TestGenerateResetToken:
+
+    def test_returns_none_when_user_not_found(self):
+        from app.services.user_service import generate_reset_token
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        result = generate_reset_token(db, "noexiste@example.com")
+
+        assert result is None
+        db.commit.assert_not_called()
+
+    def test_returns_token_and_persists_when_user_exists(self):
+        from app.services.user_service import generate_reset_token
+
+        user = _make_user()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        token = generate_reset_token(db, user.email)
+
+        assert token is not None
+        assert len(token) > 20  # token_urlsafe(32) -> ~43 chars
+        assert user.reset_password_token == token
+        assert user.reset_password_token_expires is not None
+        db.commit.assert_called_once()
+
+    def test_token_expiration_is_within_configured_hours(self):
+        from app.services.user_service import generate_reset_token
+        from app import config
+
+        user = _make_user()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        before = datetime.now(timezone.utc)
+        generate_reset_token(db, user.email)
+        after = datetime.now(timezone.utc)
+
+        expected_delta = timedelta(hours=config.RESET_TOKEN_EXPIRE_HOURS)
+        assert before + expected_delta <= user.reset_password_token_expires <= after + expected_delta
+
+    def test_token_is_urlsafe_string(self):
+        """El token generado no debe contener caracteres problemáticos para URLs."""
+        import re
+        from app.services.user_service import generate_reset_token
+
+        user = _make_user()
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        token = generate_reset_token(db, user.email)
+
+        assert isinstance(token, str)
+        assert re.match(r'^[A-Za-z0-9\-_]+$', token)
+
+
+# reset_password_with_token
+
+@pytest.mark.unit
+class TestResetPasswordWithToken:
+
+    def test_returns_false_when_token_not_found(self):
+        from app.services.user_service import reset_password_with_token
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        ok, msg = reset_password_with_token(db, "token_falso", "nueva1234")
+
+        assert ok is False
+        assert "inválido" in msg.lower() or "utilizado" in msg.lower()
+
+    def test_returns_false_when_token_expired(self):
+        from app.services.user_service import reset_password_with_token
+
+        expired = datetime.now(timezone.utc) - timedelta(minutes=1)
+        user = _make_user(reset_token="tok_exp", token_expires=expired)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        ok, msg = reset_password_with_token(db, "tok_exp", "nueva1234")
+
+        assert ok is False
+        assert "expirado" in msg.lower()
+        assert user.reset_password_token is None
+        assert user.reset_password_token_expires is None
+
+    def test_returns_true_and_updates_password_with_valid_token(self):
+        from app.services.user_service import reset_password_with_token
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        user = _make_user(reset_token="tok_valido", token_expires=future)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        ok, msg = reset_password_with_token(db, "tok_valido", "nueva_segura")
+
+        assert ok is True
+        assert user.hashed_password != "hashed_old"
+        assert user.reset_password_token is None
+        assert user.reset_password_token_expires is None
+        db.commit.assert_called_once()
+
+    def test_token_invalidated_after_successful_reset(self):
+        """El mismo token no puede usarse dos veces."""
+        from app.services.user_service import reset_password_with_token
+
+        future = datetime.now(timezone.utc) + timedelta(hours=1)
+        user = _make_user(reset_token="tok_unico", token_expires=future)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.side_effect = [user, None]
+
+        reset_password_with_token(db, "tok_unico", "pass1")
+        ok2, _ = reset_password_with_token(db, "tok_unico", "pass2")
+
+        assert ok2 is False
+
+    def test_handles_naive_datetime_from_db(self):
+        """Cubre el caso de BD que devuelve datetime sin tzinfo (SQLite)."""
+        from app.services.user_service import reset_password_with_token
+
+        # datetime naive intencionado: simula lo que devuelve SQLite
+        naive_future = datetime.now() + timedelta(hours=1)
+        user = _make_user(reset_token="tok_naive", token_expires=naive_future)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        ok, _ = reset_password_with_token(db, "tok_naive", "pass_nueva")
+
+        assert ok is True
+
+    def test_returns_false_when_expires_is_none(self):
+        """Si el campo expires es None en BD, el token se considera expirado."""
+        from app.services.user_service import reset_password_with_token
+
+        user = _make_user(reset_token="tok_sin_exp", token_expires=None)
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = user
+
+        ok, msg = reset_password_with_token(db, "tok_sin_exp", "pass1234")
+
+        assert ok is False
+        assert "expirado" in msg.lower()
+
+
+# POST /auth/forgot-password
+
+@pytest.mark.unit
+class TestForgotPasswordEndpoint:
+
+    def test_always_returns_202_even_for_unknown_email(self):
+        client = _get_client()
+
+        with patch("app.api.routes.auth.generate_reset_token", return_value=None), \
+             patch("app.api.routes.auth.send_reset_password_email") as mock_send:
+
+            resp = client.post("/auth/forgot-password", json={"email": "no@existe.com"})
+
+        assert resp.status_code == 202
+        mock_send.assert_not_called()
+
+    def test_sends_email_when_user_exists(self):
+        client = _get_client()
+
+        with patch("app.api.routes.auth.generate_reset_token", return_value="tok123"), \
+             patch("app.api.routes.auth.send_reset_password_email") as mock_send:
+
+            resp = client.post("/auth/forgot-password", json={"email": "user@existe.com"})
+
+        assert resp.status_code == 202
+        mock_send.assert_called_once_with(to_email="user@existe.com", reset_token="tok123")
+
+    def test_response_body_contains_message(self):
+        """La respuesta siempre incluye el campo message independientemente del email."""
+        client = _get_client()
+
+        with patch("app.api.routes.auth.generate_reset_token", return_value=None), \
+             patch("app.api.routes.auth.send_reset_password_email"):
+
+            resp = client.post("/auth/forgot-password", json={"email": "x@test.com"})
+
+        assert "message" in resp.json()
+        assert len(resp.json()["message"]) > 0
+
+    def test_rejects_invalid_email_format(self):
+        """Un email malformado debe devolver 422 (validacion Pydantic)."""
+        client = _get_client()
+
+        resp = client.post("/auth/forgot-password", json={"email": "no-es-un-email"})
+
+        assert resp.status_code == 422
+
+    def test_rejects_missing_email_field(self):
+        """Sin campo email debe devolver 422."""
+        client = _get_client()
+
+        resp = client.post("/auth/forgot-password", json={})
+
+        assert resp.status_code == 422
+
+
+# POST /auth/reset-password
+
+@pytest.mark.unit
+class TestResetPasswordEndpoint:
+
+    def test_returns_400_on_invalid_token(self):
+        client = _get_client()
+
+        with patch(
+            "app.api.routes.auth.reset_password_with_token",
+            return_value=(False, "Token invalido o ya utilizado."),
+        ):
+            resp = client.post(
+                "/auth/reset-password",
+                json={"token": "malo", "new_password": "pass1234"},
+            )
+
+        assert resp.status_code == 400
+
+    def test_returns_400_on_expired_token(self):
+        client = _get_client()
+
+        with patch(
+            "app.api.routes.auth.reset_password_with_token",
+            return_value=(False, "El enlace de recuperacion ha expirado. Solicita uno nuevo."),
+        ):
+            resp = client.post(
+                "/auth/reset-password",
+                json={"token": "tok_exp", "new_password": "pass1234"},
+            )
+
+        assert resp.status_code == 400
+        assert "expirado" in resp.json()["detail"].lower()
+
+    def test_returns_200_on_valid_token(self):
+        client = _get_client()
+
+        with patch(
+            "app.api.routes.auth.reset_password_with_token",
+            return_value=(True, "Contrasena actualizada correctamente."),
+        ):
+            resp = client.post(
+                "/auth/reset-password",
+                json={"token": "tok_valido", "new_password": "nuevapass"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["message"] == "Contrasena actualizada correctamente."
+
+    def test_rejects_short_password(self):
+        """new_password con menos de 6 chars debe fallar en validacion Pydantic (422)."""
+        client = _get_client()
+
+        resp = client.post(
+            "/auth/reset-password",
+            json={"token": "tok", "new_password": "abc"},
+        )
+
+        assert resp.status_code == 422
+
+    def test_rejects_missing_token(self):
+        """Sin campo token debe devolver 422."""
+        client = _get_client()
+
+        resp = client.post(
+            "/auth/reset-password",
+            json={"new_password": "pass1234"},
+        )
+
+        assert resp.status_code == 422
+
+    def test_rejects_missing_new_password(self):
+        """Sin campo new_password debe devolver 422."""
+        client = _get_client()
+
+        resp = client.post(
+            "/auth/reset-password",
+            json={"token": "tok123"},
+        )
+
+        assert resp.status_code == 422
+
+    def test_rejects_password_exceeding_max_length(self):
+        """Una contrasena de mas de 128 caracteres debe devolver 422."""
+        client = _get_client()
+
+        resp = client.post(
+            "/auth/reset-password",
+            json={"token": "tok123", "new_password": "a" * 129},
+        )
+
+        assert resp.status_code == 422


### PR DESCRIPTION
- Añade columnas reset_password_token y reset_password_token_expires al modelo User
- Implementa generate_reset_token y reset_password_with_token en user_service
- Añade endpoints POST /auth/forgot-password y POST /auth/reset-password
- Añade send_reset_password_email con soporte SMTP y modo dev
- Añade schemas ForgotPasswordRequest, ResetPasswordRequest y MessageResponse
- 22 tests unitarios, 0 warnings
- ADR-019 documentando la decision de diseno

Closes #34