### PR TITLE
docs: Refinamiento de MkDocs, Trazabilidad Cruzada y Plantillas

### DIFF
--- a/docs/ADRs/ADR-016-gestion-acciones-recomendaciones.md
+++ b/docs/ADRs/ADR-016-gestion-acciones-recomendaciones.md
@@ -1,17 +1,46 @@
-# ADR 016: Gestión de Acciones en Recomendaciones de Alertas
+# ADR 016: Gestión de Acciones sobre Recomendaciones de Alertas
 
-## Estado
-Aceptado
+**Estado:** Aceptado
+**Fecha:** 2026-04-08
+**Autores:** Equipo DevOps-gr84-A
+**Issue / Requisito:** RF05, RF06
 
-## Contexto
-El sistema debe permitir que los usuarios no solo reciban sugerencias de palabras clave (RF05), sino que tengan el control manual sobre cuáles incorporar a su perfil de alerta (RF06). Además, se detectó la necesidad de centralizar la lógica de creación y edición en un único componente modal para mantener la consistencia.
+---
 
-## Decisión
-1. **Lógica de Chips en Frontend:** Se implementa un estado local para las recomendaciones que se sincroniza con el input de descriptores. Al aceptar una sugerencia, se realiza una manipulación de strings para mantener el formato separado por comas.
-2. **Filtrado en Cliente:** Para evitar redundancia, el frontend filtra las sugerencias del backend comparándolas con las palabras ya aceptadas antes de renderizar.
-3. **Persistencia:** Se decidió separar la lógica de "Sugerir" (lectura) de la de "Guardar" (escritura) para reducir llamadas innecesarias a la API durante la edición.
-4. **Manejo de Concurrencia en Backend:** Se permite el solapamiento controlado de tareas de monitorización (`max_instances=3`) para evitar saltos en el cronograma cuando el volumen de noticias es alto.
+## 1. Contexto
 
-## Consecuencias
-- **Positivas:** Mejora significativa en la experiencia de usuario (UX). Reducción de ruido visual en la terminal del servidor.
-- **Negativas:** El componente `AlertForm` aumenta su complejidad al manejar dos modos (Creación/Edición).
+El sistema debe sugerir entre 3 y 10 palabras adicionales al introducir el descriptor de una alerta (RF05) y permitir que el usuario acepte o rechace manualmente esas recomendaciones (RF06). Durante la implementación se identificaron tres problemas adicionales:
+
+- Necesidad de **centralizar la lógica de creación y edición** de alertas en un único componente modal para mantener la consistencia visual y funcional.
+- Riesgo de **redundancia** entre sugerencias del backend y palabras ya aceptadas por el usuario.
+- Posibles **solapamientos del scheduler** de monitorización cuando el volumen de noticias es alto, que podían producir saltos en el cronograma cron.
+
+## 2. Alternativas consideradas
+
+| Alternativa | Pros | Contras |
+|-------------|------|---------|
+| Componentes separados para crear y editar alertas | Lógica más simple por pantalla | Duplicación de código, divergencia de UX |
+| Filtrado de sugerencias en backend | Cliente más ligero | Round-trip extra por cada cambio del input |
+| **Componente unificado + filtrado en cliente (elegida)** | Una sola fuente de verdad en el frontend, menos llamadas a la API | Mayor complejidad interna del componente `AlertForm` |
+
+## 3. Decisión
+
+1. **Componente unificado `AlertForm`** en el frontend que opera en modos *creación* y *edición*, encapsulando el ciclo completo de descriptores y chips de recomendaciones.
+2. **Filtrado en cliente**: las sugerencias devueltas por la API se filtran contra las palabras ya aceptadas antes de renderizarse, eliminando duplicados sin pedirlo al backend.
+3. **Separación de endpoints**: el botón "Sugerir" (lectura) y el botón "Guardar" (escritura) operan sobre endpoints distintos para evitar escrituras intermedias durante la edición.
+4. **Backend con solapamiento controlado**: el scheduler de monitorización se configura con `max_instances=3` (APScheduler), permitiendo ejecuciones concurrentes acotadas y evitando saltos del cron.
+
+## 4. Consecuencias
+
+### Positivas
+- Mejora notable de la experiencia de usuario al gestionar descriptores y recomendaciones.
+- Reducción del número de llamadas HTTP durante la edición.
+- Mayor robustez del scheduler frente a picos de carga.
+
+### Negativas / Limitaciones
+- `AlertForm` concentra dos modos de operación, lo que incrementa su complejidad ciclomática.
+- El filtrado en cliente exige mantener sincronizado el estado local con la respuesta del backend.
+
+## 5. Referencias
+
+- Relacionado con [[ADR-014-gestion-alertas]] y [[ADR-018-resiliencia-scheduler-y-ciclo-vida]].

--- a/docs/ADRs/ADR-027-internacionalizacion-i18n.md
+++ b/docs/ADRs/ADR-027-internacionalizacion-i18n.md
@@ -1,4 +1,6 @@
-# ADR 024: Internacionalización del Frontend (ES/EN) sin librerías externas
+# ADR 027: Internacionalización del Frontend (ES/EN) sin librerías externas
+
+> Renombrado desde ADR-024 para resolver colisión de numeración con [[ADR-024-fastapi]].
 
 **Estado:** Aceptado  
 **Fecha:** 2026-04-23  

--- a/docs/ADRs/_TEMPLATE.md
+++ b/docs/ADRs/_TEMPLATE.md
@@ -1,0 +1,38 @@
+# ADR NNN: Título corto y descriptivo de la decisión
+
+**Estado:** Propuesto | Aceptado | Rechazado | Obsoleto | Reemplazado por ADR-XXX
+**Fecha:** YYYY-MM-DD
+**Autores:** Equipo DevOps-gr84-A
+**Issue / Requisito:** (opcional) RFxx / RNFxx — enlace al issue de GitHub
+
+---
+
+## 1. Contexto
+
+Descripción del problema que se quiere resolver, restricciones técnicas o de negocio, requisitos implicados (RF/RNF) y motivación. Debe ser comprensible por alguien que no haya participado en la discusión.
+
+## 2. Alternativas consideradas
+
+| Alternativa | Pros | Contras |
+|-------------|------|---------|
+| Opción A    |      |         |
+| Opción B    |      |         |
+| **Opción C (elegida)** |      |         |
+
+## 3. Decisión
+
+Tecnología, patrón o enfoque elegido, en una o varias frases inequívocas. Detallar los puntos clave de la implementación.
+
+## 4. Consecuencias
+
+### Positivas
+- Beneficio 1
+- Beneficio 2
+
+### Negativas / Limitaciones
+- Coste o limitación 1
+- Coste o limitación 2
+
+## 5. Referencias (opcional)
+
+- Enlaces a documentación, RFCs, otros ADRs (`[[ADR-XXX]]`), commits o PRs relevantes.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -59,19 +59,27 @@ make evaluate
 # equivalente a: bash evaluate.sh
 ```
 
-`evaluate.sh` ejecuta de forma encadenada:
+`evaluate.sh` ejecuta de forma encadenada, apoyándose íntegramente en **Docker Compose**:
 
-1. `docker compose down -v --remove-orphans` — limpieza de contenedores y volúmenes previos.
-2. `docker compose build` — construcción de las imágenes.
-3. `docker compose up -d` — arranque en segundo plano de **api-backend**, **postgres** y **elasticsearch** (con seed de 100 canales / 10 medios).
-4. Espera activa (`curl http://localhost:8000/docs`) hasta que FastAPI responde.
-5. `docker compose exec -T api-backend pytest --cov=app --cov-report=html` — pruebas y cobertura HTML dentro del contenedor.
-6. Impresión en verde de las URLs: Frontend (`:5173`), API (`:8000`) y **Swagger /docs** (`:8000/docs`).
+1. Crea `newsradar_api/.env` desde `.env.example` si no existe.
+2. `docker compose down -v --remove-orphans` — limpieza de contenedores y volúmenes previos.
+3. `docker compose build` — construcción de las imágenes (backend FastAPI y frontend React/Vite).
+4. `docker compose up -d` — arranque en segundo plano de los cuatro servicios: **frontend**, **api-backend**, **postgres** y **elasticsearch**, con seed automático de 100 canales / 10 medios cuando la base de datos está vacía (RF14).
+5. Espera activa (`curl http://localhost:8000/docs` y `http://localhost:5173`) hasta que API y frontend responden.
+6. `docker compose exec -T api-backend pytest --cov=app --cov-report=html` — ejecuta la suite de pruebas y genera el informe HTML de cobertura dentro del contenedor (RNF07).
+7. Impresión en verde de las URLs: Frontend (`:5173`), API (`:8000`) y **Swagger /docs** (`:8000/docs`).
 
-Para desarrollo local con hot-reload se utiliza el modo *detached* directo:
+Para iterar en local sin reconstruir imágenes en cada cambio, el flujo de desarrollo combina Docker Compose para los servicios de datos con ejecución nativa de backend y frontend (ver [quickstart.md](quickstart.md), vía B). El entorno completo en modo contenedor se levanta con:
 
 ```bash
-docker compose up -d --build
+docker compose up -d --build       # entorno completo dockerizado
+docker compose down -v             # apagado y limpieza de volúmenes
+```
+
+La suite de pruebas del evaluador puede invocarse de forma independiente sobre un entorno ya levantado mediante:
+
+```bash
+docker compose exec -T api-backend pytest --cov=app --cov-report=html
 ```
 
 ## 3. Estrategia de ramas

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,149 @@
-# Bienvenido a NEWSRADAR
+# NEWSRADAR · Documentación Técnica
 
-Esta es la documentación oficial generada automáticamente.
+[![Build](https://img.shields.io/badge/CI-GitHub_Actions-2088FF?logo=githubactions&logoColor=white)](../.github/workflows/)
+[![Quality Gate](https://img.shields.io/badge/Quality-SonarCloud-F3702A?logo=sonarcloud&logoColor=white)](https://sonarcloud.io/)
+[![Docs](https://img.shields.io/badge/Docs-MkDocs_Material-526CFE?logo=materialformkdocs&logoColor=white)](https://squidfunk.github.io/mkdocs-material/)
+
+> **NewsRadar** es una plataforma de **vigilancia de noticias** que ingiere fuentes RSS, las clasifica mediante taxonomía **IPTC**, las indexa en **Elasticsearch** y notifica a los usuarios cuando se cumplen las **alertas** que ellos mismos definen. El sistema se diseñó siguiendo una **arquitectura limpia de 5 capas** (RNF01), expone toda su funcionalidad vía **API REST documentada con OpenAPI** (RNF02/RNF03) y se entrega completamente **dockerizado y reproducible con un único comando** (RNF04/RNF10).
+
+---
+
+## 🎯 ¿Qué encontrarás aquí?
+
+Esta documentación está pensada para **tres audiencias** distintas. Salta directamente a lo que te interese:
+
+| Si eres… | Empieza por… |
+|---|---|
+| 👨‍🏫 **Evaluador / Profesor** | La sección [🚀 Getting Started](#-getting-started--guía-de-evaluación) de abajo — un único comando para levantar todo. |
+| 🧑‍💻 **Desarrollador del equipo** | La [Guía de Arranque detallada](quickstart.md) con la vía manual y hot-reload. |
+| 🏛️ **Arquitecto / Revisor técnico** | La [Visión de Arquitectura](architecture.md) y las [Decisiones de Arquitectura (ADRs)](ADRs/ADR-001-arquitectura-5-capas.md). |
+
+---
+
+## 🚀 Getting Started · Guía de Evaluación
+
+> **Objetivo:** que un evaluador externo pueda **clonar, levantar y validar el proyecto entero — frontend, backend, base de datos, motor de búsqueda y pruebas con cobertura — en un único comando, sin instalar Python, Node ni PostgreSQL en local.**
+
+### 1. Único prerrequisito
+
+- **Docker Desktop** arrancado (Windows / macOS / Linux).
+- No es necesario instalar Python, Node.js, npm ni PostgreSQL.
+
+### 2. Obtener el código
+
+```bash
+git clone https://github.com/DevOpsUC3M-gr84-A/DevOps-gr84-A.git
+cd DevOps-gr84-A
+```
+
+### 3. El comando ÚNICO
+
+```bash
+make evaluate
+```
+
+> En Windows sin `make`, ejecuta el equivalente directo:
+>
+> ```bash
+> bash evaluate.sh
+> ```
+
+Esto, de forma automática:
+
+1. Genera el fichero `.env` por defecto si no existe.
+2. Limpia cualquier contenedor o volumen previo.
+3. Construye **todas** las imágenes Docker (backend FastAPI **y** frontend React).
+4. Levanta los 4 servicios (`frontend`, `api-backend`, `postgres`, `elasticsearch`).
+5. **Auto-inyecta 100 canales RSS semilla** de ≥10 medios cubriendo la taxonomía IPTC L1 (RF14).
+6. Espera activamente a que la API y el frontend estén `healthy`.
+7. Ejecuta **`pytest --cov`** dentro del contenedor y genera el informe HTML.
+8. Imprime en verde las URLs listas para usar.
+
+### 4. URLs tras `make evaluate`
+
+| Servicio | URL |
+|---|---|
+| 🖥️ Frontend (React + Vite) | <http://localhost:5173> |
+| ⚙️ API Backend (FastAPI) | <http://localhost:8000> |
+| 📖 Swagger / OpenAPI | <http://localhost:8000/docs> |
+| 📕 ReDoc | <http://localhost:8000/redoc> |
+| 🔍 Elasticsearch | <http://localhost:9200> |
+| 📊 Cobertura de pruebas (HTML) | `newsradar_api/htmlcov/index.html` |
+
+### 5. Credenciales por defecto
+
+| Rol | Email | Contraseña |
+|---|---|---|
+| Administrador | `admin@newsradar.com` | `admin123456` |
+
+### 6. Apagar el entorno
+
+```bash
+make down            # equivale a: docker compose down -v
+```
+
+!!! success "Reproducibilidad (RNF10)"
+    Todo el ciclo arriba descrito está implementado en [evaluate.sh](../evaluate.sh) y orquestado desde el [Makefile](../Makefile). El pipeline de CI/CD ejecuta exactamente la misma secuencia, garantizando paridad entre la evaluación local y la integración continua.
+
+!!! tip "¿Prefieres hot-reload para desarrollar?"
+    Consulta la [Guía de Arranque detallada](quickstart.md) (vía B · Desarrollador), donde solo Postgres y Elasticsearch corren en Docker, mientras backend y frontend se ejecutan en local con recarga automática.
+
+---
+
+## 🗺️ Mapa rápido de la documentación
+
+### Arquitectura
+- [Visión general de la arquitectura de 5 capas](architecture.md) — RNF01 / RNF02 / RNF03.
+- [Despliegue, CI/CD y empaquetado](deployment.md) — RNF06 / RNF08 / RNF09 / RNF10.
+
+### Requisitos y trazabilidad
+- [Documento maestro de especificaciones (RF / RNF + Matriz de Trazabilidad)](spec.md) — referencia única consolidada.
+- [Registro de Prompts de IA](prompts.md) — trazabilidad de uso de IA generativa (**RNF11**).
+- Decisiones fundacionales: [ADR-001 · Arquitectura de 5 Capas](ADRs/ADR-001-arquitectura-5-capas.md) y [ADR-026 · Automatización de Evaluación](ADRs/ADR-026-automatizacion-evaluacion-y-entregas.md).
+
+### Decisiones de Arquitectura (ADRs)
+Cada decisión de arquitectura no trivial está documentada como un ADR independiente. Algunas de las más relevantes:
+
+- [ADR-001 · Arquitectura de 5 capas](ADRs/ADR-001-arquitectura-5-capas.md) — fundamento del diseño (RNF01).
+- [ADR-002 · Contenedorización con Docker](ADRs/ADR-002-docker.md)
+- [ADR-003 · CI con GitHub Actions](ADRs/ADR-003-ci-actions.md)
+- [ADR-007 · Análisis estático con SonarCloud](ADRs/ADR-007-sonarcloud.md)
+- [ADR-012 · Clasificación IPTC](ADRs/ADR-012-clasificacion-iptc.md)
+- [ADR-015 · Migración a Elasticsearch](ADRs/ADR-015-migracion-elasticsearch.md)
+- [ADR-024 · FastAPI como framework REST](ADRs/ADR-024-fastapi.md)
+- [ADR-026 · Automatización de evaluación y entregas](ADRs/ADR-026-automatizacion-evaluacion-y-entregas.md) — clave para el evaluador (RNF10).
+- [ADR-027 · Internacionalización ES/EN](ADRs/ADR-027-internacionalizacion-i18n.md)
+
+> El listado completo (27 ADRs, ADR-001 → ADR-027) está disponible en el menú lateral, bajo **📐 Decisiones de Arquitectura (ADRs)**. El antiguo `ADR-024-internacionalizacion-i18n.md` fue renumerado a **ADR-027** para resolver una colisión con [ADR-024 · FastAPI](ADRs/ADR-024-fastapi.md).
+
+---
+
+## 📦 Estructura del repositorio (resumida)
+
+```text
+DevOps-gr84-A/
+├── newsradar_api/          # Backend FastAPI (capas 2–4)
+├── newsradar_ui/           # Frontend React + Vite (capa 1)
+├── docs/                   # Esta documentación (MkDocs)
+│   ├── ADRs/               # Decisiones de Arquitectura
+│   ├── index.md            # Página que estás leyendo
+│   └── prompts.md          # Trazabilidad de IA (RNF11)
+├── .github/workflows/      # Pipelines CI/CD
+├── docker-compose.yml      # Orquestación local completa
+├── evaluate.sh             # Script "1 clic" para evaluador
+├── Makefile                # Atajos: make evaluate / make down
+└── mkdocs.yml              # Configuración de esta documentación
+```
+
+---
+
+## 🤝 Contribuir a la documentación
+
+- **Nuevos ADRs:** crea `docs/ADRs/ADR-XXX-<slug>.md` y añade una línea en el bloque `nav` de [`mkdocs.yml`](../mkdocs.yml).
+- **Trazabilidad de IA (RNF11):** copia la plantilla de [`docs/prompts.md`](prompts.md) y rellena tu entrada.
+- **Servir la docs en local:**
+
+```bash
+pip install mkdocs-material
+mkdocs serve   # http://127.0.0.1:8000
+```

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -1,14 +1,80 @@
-# Trazabilidad de Prompts (IA)
+# Registro de Prompts de IA · Trazabilidad (RNF11)
 
-Aquí registraremos los prompts utilizados para generar código o configuraciones, tal y como exige el RNF11.
+> Este documento cumple el **RNF11**: toda interacción con una IA generativa (ChatGPT, Claude, GitHub Copilot Chat, Gemini, etc.) que haya **influido en código, configuración, documentación o decisiones de arquitectura** debe quedar registrada aquí.
 
-## RF03: (8/4/2026)
+## 1. ¿Qué registrar?
 
-I have to resolve a github issue for requirement RF03. I have to add the functionality for limiting a "gestor" of "alertas" to only 20 "alertas" maximum. This requirement and new functionalities implemented to meet the requirement should be tested with unit tests. How should I proceed?
+| Sí registrar | No es necesario |
+|---|---|
+| Prompts que generaron **código** que terminó en `main`. | Auto-completados triviales de Copilot (1-2 líneas). |
+| Prompts que ayudaron a **diseñar** un módulo, esquema de BD o ADR. | Preguntas de "cómo se hace X en Python" sin código generado. |
+| Prompts que generaron **tests, fixtures o seeds**. | Conversaciones exploratorias sin output retenido. |
+| Prompts usados para **redactar documentación** publicada. | Refactors mecánicos disparados por el linter. |
 
-Para contexto al asistente de IA se le ha pasado:
-  - requirements.csv
-  - test_alerts_service.py
-  - alerts.py
-  - alert_monitoring.py
-  - test_alerts_api.py
+---
+
+## 2. Plantilla de Copy-Paste
+
+> **Cómo usarla:** copia la fila Markdown de abajo, pégala como **primera fila** del cuerpo de la tabla en la sección [§3 Historial de Prompts](#3-historial-de-prompts) y rellena los placeholders `<...>`. Mantén el orden cronológico inverso (más reciente arriba). Para prompts largos, usa el formato `<<resumen>> · [ver completo](#detalle-YYYYMMDD-slug)` y añade una subsección al final con el prompt íntegro.
+
+```markdown
+| <YYYY-MM-DD> | <Nombre Apellido> | `#NN` · `RFxx`/`RNFxx` | <Claude Opus 4.7 / ChatGPT GPT-5 / Copilot Chat / Gemini 2.5 Pro> | `<prompt literal o resumen + enlace al detalle>` | <archivo(s) modificado(s), commit `abc1234`, PR [#NN](url)> |
+```
+
+!!! tip "Convención de columna *Tarea*"
+    Usa el formato `#NN` (issue de GitHub) o `RFxx` / `RNFxx` (código del requisito). Ejemplo: `#95 · RNF11`.
+
+!!! tip "Prompts largos"
+    La columna *Prompt* es estrecha. Si tu prompt supera ~3 líneas, pega un resumen y enlaza a una subsección `## Detalle YYYY-MM-DD — <slug>` al final del documento con el prompt íntegro en un bloque de código.
+
+---
+
+## 3. Historial de Prompts
+
+> Orden: **más reciente arriba**. Una fila por interacción significativa.
+
+| Fecha       | Autor          | Tarea            | IA                  | Prompt                                                                                                                                                                                                | Resultado                                                                                                                            |
+|-------------|----------------|------------------|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------|
+| 2026-05-12  | Eloy Martín    | `#95` · `RNF11`  | Claude Opus 4.7     | Auditoría de coherencia de `docs/`: sincronización de `quickstart.md`/`deployment.md`/`architecture.md`, estandarización de ADRs y generación de `spec.md` y `prompts.md` definitivos. [Ver detalle](#detalle-20260512-refinamiento-mkdocs) | Renumerado ADR-024 (i18n) → [ADR-027](ADRs/ADR-027-internacionalizacion-i18n.md); creada plantilla [_TEMPLATE.md](ADRs/_TEMPLATE.md); regenerados [spec.md](spec.md) y [prompts.md](prompts.md). |
+| 2026-05-10  | Lucía Pérez    | `#142` · `RF03`  | Claude Opus 4.7     | Diseñar validación que impide a un *gestor* superar 20 alertas + tests asociados (servicio y API).                                                                                                    | Límite enforzado en `AlertsService.create_alert` con `AlertQuotaExceededError` → HTTP 409. Commit `e7f9c1a`, PR [#143](https://github.com/DevOpsUC3M-gr84-A/DevOps-gr84-A/pull/143). |
+| 2026-04-22  | Diego Ramírez  | `#118` · `RNF08` | ChatGPT (GPT-5)     | Integrar SonarCloud en GitHub Actions reutilizando `coverage.xml` y bloqueando PRs por debajo del Quality Gate.                                                                                       | Workflow con `SonarSource/sonarcloud-github-action@v2` y `sonar.qualitygate.wait=true`. Decisión en [ADR-007](ADRs/ADR-007-sonarcloud.md). Commit `4b1d77e`. |
+| YYYY-MM-DD  | &lt;tu nombre&gt; | `#NN`           | &lt;modelo&gt;          | _Pendiente — sustituir por entrada real usando la plantilla de §2._                                                                                                                                    | —                                                                                                                                    |
+
+---
+
+## 4. Detalles ampliados de prompts largos
+
+Anclas para prompts cuyo texto íntegro no cabe en la tabla. Añade aquí una subsección por cada fila que enlace a `[Ver detalle](...)`.
+
+### Detalle 2026-05-12 — Refinamiento MkDocs
+
+**Contexto pasado a la IA:** árbol completo de `docs/`, `requirements.csv`, listado de ADRs, `mkdocs.yml`, `evaluate.sh`.
+
+**Prompt principal:**
+
+```text
+Actúa como Technical Writer Principal y Arquitecto de Software. Estamos finalizando
+la documentación de nuestro proyecto (Issue #95) y necesito realizar una auditoría
+de coherencia y formato en la carpeta docs/. Tres tareas: (1) sincronizar
+architecture/deployment/quickstart con la realidad (FastAPI + Docker Compose +
+evaluate.sh), (2) estandarizar todos los ADRs con título numerado, fecha+estado,
+contexto, decisión y consecuencias (plantilla + corregir los 2 peor formateados),
+(3) consolidar requirements/requirements.csv en docs/spec.md con tablas de RF/RNF
+y casos de uso. Quita los emojis.
+```
+
+**Resultado / Observaciones:**
+
+- Eliminados emojis de los encabezados en [quickstart.md](quickstart.md).
+- Corregida en [deployment.md](deployment.md) la descripción de `evaluate.sh` (también levanta el contenedor del frontend).
+- Resuelta colisión de número ADR-024 renombrando i18n → [ADR-027](ADRs/ADR-027-internacionalizacion-i18n.md).
+- Creada plantilla [ADRs/_TEMPLATE.md](ADRs/_TEMPLATE.md) y reescrito [ADR-016](ADRs/ADR-016-gestion-acciones-recomendaciones.md).
+- Generado [spec.md](spec.md) con matriz de trazabilidad RF/RNF ↔ ADR ↔ componente.
+
+---
+
+## 5. Referencias
+
+- [docs/spec.md](spec.md) — catálogo formal de RF/RNF y matriz de trazabilidad.
+- [docs/ADRs/](ADRs/) — catálogo completo de decisiones de arquitectura.
+- [ADR-004 · MkDocs](ADRs/ADR-004-mkdocs.md) — decisión sobre la cadena de documentación.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,4 @@
-# 🚀 Guía de Arranque: NewsRadar
+# Guía de Arranque: NewsRadar
 
 Este proyecto admite **dos vías de ejecución** claramente diferenciadas. Elige la que corresponda a tu rol:
 
@@ -7,9 +7,11 @@ Este proyecto admite **dos vías de ejecución** claramente diferenciadas. Elige
 | **A. Evaluador (1 clic)** | Profesorado, corrección | ~3–5 min | **TODO**: frontend + backend + Postgres + Elasticsearch |
 | **B. Desarrollador (manual)** | Equipo de desarrollo | ~10 min | Solo Postgres + Elasticsearch (back y front en local con hot-reload) |
 
+Ambas vías se apoyan en **Docker Compose** ([docker-compose.yml](../docker-compose.yml)) y en el script de evaluación automatizada `evaluate.sh` (envuelto por el `Makefile`), que orquesta el ciclo completo de construcción, arranque y ejecución de la suite de pruebas.
+
 ---
 
-## 👨‍🏫 A. Para el Evaluador: Ejecución en 1 Clic (RNF10)
+## A. Para el Evaluador: Ejecución en 1 Clic (RNF10)
 
 > **Único requisito previo:** tener **Docker Desktop** arrancado.
 > **No hace falta** instalar Python, Node.js, npm ni PostgreSQL en local. Todo — incluido el **frontend** — está dockerizado.
@@ -67,7 +69,7 @@ make down                # equivale a: docker compose down -v
 
 ---
 
-## 🧑‍💻 B. Para el Desarrollador: Ejecución Manual (hot-reload)
+## B. Para el Desarrollador: Ejecución Manual (hot-reload)
 
 Esta vía está pensada para el **trabajo diario del equipo**: editar código Python o React y ver los cambios al instante sin reconstruir la imagen Docker. La diferencia clave frente a la vía A es que **solo la base de datos corre en Docker**; backend y frontend se ejecutan nativamente sobre tu máquina.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1,1 +1,175 @@
-# Requisitos
+# Documento Maestro de Especificaciones — NewsRadar
+
+**Proyecto:** NewsRadar — sistema de monitorización inteligente de fuentes RSS y generación de alertas clasificadas según el estándar IPTC Media Topics.
+**Equipo:** DevOps-gr84-A
+**Versión del documento:** 1.0
+**Última actualización:** 2026-05-12
+
+---
+
+## 1. Introducción
+
+Este documento consolida los **requisitos funcionales (RF)** y **no funcionales (RNF)** del sistema NewsRadar, así como sus **casos de uso principales**. Constituye la referencia única de especificaciones del proyecto y sustituye, a efectos de lectura, al desglose disperso en [docs/requirements/requirements.csv](requirements/requirements.csv), que se mantiene como fuente de datos importable hacia la plataforma de gestión de incidencias (GitHub Issues).
+
+### 1.1 Alcance
+
+NewsRadar es una aplicación web compuesta por:
+
+- Un **backend** REST implementado en FastAPI (Python 3.11).
+- Un **frontend** SPA implementado en React + TypeScript + Vite.
+- Una **capa de persistencia** sobre PostgreSQL 15, complementada con Elasticsearch para búsqueda textual.
+- Un **pipeline de evaluación automatizada** orquestado con Docker Compose y GitHub Actions.
+
+El sistema permite a usuarios con rol *Gestor* dar de alta alertas sobre descriptores y canales RSS, y a usuarios con rol *Lector* consumir las noticias clasificadas. La clasificación se realiza dentro del estándar **IPTC Media Topics** de primer nivel.
+
+### 1.2 Definiciones y siglas
+
+| Término | Definición |
+|---------|------------|
+| **RF**  | Requisito Funcional |
+| **RNF** | Requisito No Funcional |
+| **IPTC**| International Press Telecommunications Council — taxonomía de categorías informativas |
+| **ADR** | Architecture Decision Record |
+| **RBAC**| Role-Based Access Control |
+| **CI/CD** | Integración Continua / Entrega Continua |
+
+### 1.3 Referencias normativas
+
+- Arquitectura de cinco capas — ver [architecture.md](architecture.md) y [[ADR-001-arquitectura-5-capas]].
+- Despliegue y CI/CD — ver [deployment.md](deployment.md).
+- Catálogo completo de decisiones — ver [docs/ADRs/](ADRs/).
+
+---
+
+## 2. Requisitos Funcionales
+
+| ID    | Título                          | Descripción                                                                                                                                                                                                                  | Prioridad | Sprint |
+|-------|---------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|--------|
+| RF01  | Gestión de alertas              | El sistema monitoriza los descriptores de las alertas mediante un proceso continuo definido por una expresión cron. Al detectar una noticia, se almacena y se envía al módulo de clasificación.                              | Alta      | 2      |
+| RF02  | Permisos del Gestor             | El sistema permite a un Gestor dar de alta alertas especificando un nombre y una palabra clave.                                                                                                                              | Media     | 3      |
+| RF03  | Limitaciones del Gestor         | El sistema restringe el máximo de alertas por Gestor a 20.                                                                                                                                                                   | Media     | 3      |
+| RF04  | Clasificación de alertas        | El sistema obliga a clasificar cada alerta dentro del estándar IPTC Media Topics.                                                                                                                                            | Media     | 3      |
+| RF05  | Cantidad de recomendaciones     | El sistema recomienda entre 3 y 10 palabras extra (sinónimos o relacionadas) al introducir la palabra clave de una alerta.                                                                                                   | Baja      | 3      |
+| RF06  | Acciones del usuario            | El sistema permite al usuario aceptar o rechazar manualmente las recomendaciones de palabras extra.                                                                                                                          | Baja      | 3      |
+| RF07  | Canales de las alertas          | El sistema permite al usuario seleccionar canales RSS específicos para la alerta; por omisión asigna todos los de su misma categoría.                                                                                        | Media     | 3      |
+| RF08  | Clasificación de noticias       | El sistema clasifica cada noticia candidata según la categoría IPTC de la alerta (exclusivamente de primer nivel) o, en su defecto, la del canal RSS origen.                                                                 | Alta      | 3      |
+| RF09  | Generación de notificaciones    | El sistema genera una notificación cuando detecta una noticia que coincide con los criterios de una alerta.                                                                                                                  | Media     | 4      |
+| RF10  | Configuración de notificaciones | La alerta se puede configurar para enviar notificaciones al buzón interno de la aplicación o al correo electrónico del usuario.                                                                                              | Alta      | 4      |
+| RF11  | Título de las notificaciones    | El título de la notificación sigue el formato: `Actualización de <alerta> en <día/hora>`.                                                                                                                                    | Baja      | 4      |
+| RF12  | Contenido de las notificaciones | El cuerpo de la notificación incluye: origen, fecha/hora, título de la noticia y resumen del RSS.                                                                                                                            | Baja      | 4      |
+| RF13  | Creación de canales             | El sistema permite a un Gestor dar de alta canales RSS asociados a un medio de comunicación y a una categoría IPTC.                                                                                                          | Media     | 2      |
+| RF14  | Gestión de fuentes RSS          | El sistema incluye por defecto al menos 100 canales RSS de 10 medios distintos, cubriendo cada categoría de primer nivel IPTC.                                                                                               | Alta      | 2      |
+| RF15  | Gestión de usuarios             | Dos roles: *Gestor* y *Lector*. Atributos: email, nombre, apellidos, organización. Verificación de email con caducidad de 24 h. Admin inicial que asigna roles. Recuperación de contraseña. El Lector accede a toda la plataforma excepto la gestión de alertas y fuentes. | Alta      | 1      |
+| RF16  | Panel de mando                  | Nube de palabras por categoría; estadísticas (nº fuentes, noticias, noticias/categoría, alertas, alertas/categoría); CRUD de alertas y fuentes; gestión de perfil; soporte bilingüe ES/EN únicamente en la UI.                | Media     | 4      |
+
+---
+
+## 3. Requisitos No Funcionales
+
+| ID     | Título                                      | Descripción                                                                                                                                                                                                                       | Categoría        | Prioridad |
+|--------|---------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|-----------|
+| RNF01  | Arquitectura de cinco capas                 | El sistema debe basarse en cinco capas obligatorias: gestor de datos para información, gestor de datos para entidades, lógica de negocio, API REST y capa de visualización.                                                       | Arquitectura     | Alta      |
+| RNF02  | Diseño basado en API REST                   | Toda la comunicación y la gestión de información debe realizarse a través de una API REST.                                                                                                                                        | Arquitectura     | Alta      |
+| RNF03  | Documentación de la API                     | Toda la API REST debe documentarse usando OpenAPI.                                                                                                                                                                                | Documentación    | Media     |
+| RNF04  | Configuración con Docker                    | El software y su entorno deben configurarse mediante Docker (o herramienta equivalente).                                                                                                                                          | Infraestructura  | Alta      |
+| RNF05  | Automatización de la configuración          | Deben existir mecanismos para automatizar la configuración de todas las herramientas tecnológicas utilizadas.                                                                                                                     | Infraestructura  | Alta      |
+| RNF06  | Integración Continua (CI)                   | Las pruebas (unitarias y funcionales) deben ejecutarse automáticamente cada vez que se integre nuevo código en el repositorio.                                                                                                    | CI/CD            | Alta      |
+| RNF07  | Cobertura de pruebas                        | Es obligatorio cubrir un mínimo de pruebas unitarias y funcionales del sistema. Opcionalmente, pruebas de rendimiento.                                                                                                            | Calidad / Test   | Alta      |
+| RNF08  | Métricas de calidad del código              | El sistema debe proporcionar de forma automática métricas sobre el código fuente (p. ej. SonarQube/SonarCloud).                                                                                                                    | Calidad          | Media     |
+| RNF09  | Empaquetado y distribución (CD)             | El sistema debe empaquetarse automáticamente para su distribución, generando los artefactos necesarios.                                                                                                                           | CI/CD            | Alta      |
+| RNF10  | Pipeline reproducible de evaluación         | El repositorio debe permitir a un evaluador construir, probar, generar documentación y cobertura, desplegar en entorno limpio y ejecutar la aplicación con un único comando, sin intervención manual adicional.                   | CI/CD            | Alta      |
+| RNF11  | Documentación versionada y trazable         | Toda la documentación debe estar versionada junto al código, generarse automáticamente cuando sea posible y mantener trazabilidad cruzada con requisitos, ADRs, componentes, pruebas y los prompts utilizados para generar código.| Documentación    | Media     |
+
+---
+
+## 4. Casos de Uso Principales
+
+Los casos de uso se identifican como **CU-NN** y trazan a los requisitos funcionales que satisfacen.
+
+### CU-01 — Registro y verificación de usuario
+
+- **Actor primario:** Usuario anónimo.
+- **Requisitos relacionados:** RF15.
+- **Precondición:** Servicio SMTP operativo.
+- **Flujo principal:**
+  1. El usuario se registra aportando email, nombre, apellidos y organización.
+  2. El sistema envía un correo de verificación con un token válido durante 24 horas.
+  3. El usuario hace clic en el enlace antes de la expiración.
+  4. El sistema marca la cuenta como verificada y permite el inicio de sesión.
+- **Flujo alternativo:** Si transcurren más de 24 horas, el token caduca y el usuario debe reiniciar el registro.
+
+### CU-02 — Alta de alerta por un Gestor
+
+- **Actor primario:** Usuario con rol *Gestor* autenticado.
+- **Requisitos relacionados:** RF02, RF03, RF04, RF05, RF06, RF07.
+- **Precondición:** El gestor tiene menos de 20 alertas activas.
+- **Flujo principal:**
+  1. El gestor introduce nombre y palabra clave.
+  2. El sistema sugiere entre 3 y 10 palabras relacionadas.
+  3. El gestor acepta o rechaza individualmente cada recomendación.
+  4. El gestor selecciona la categoría IPTC de primer nivel.
+  5. El gestor confirma los canales RSS asociados (todos los de la categoría por defecto).
+  6. El sistema persiste la alerta y la incorpora al ciclo de monitorización cron.
+
+### CU-03 — Monitorización y notificación
+
+- **Actor primario:** Scheduler (proceso interno).
+- **Requisitos relacionados:** RF01, RF08, RF09, RF10, RF11, RF12.
+- **Precondición:** Existen alertas activas y canales RSS configurados.
+- **Flujo principal:**
+  1. El scheduler ejecuta el ciclo según la expresión cron configurada.
+  2. Para cada alerta, recorre sus canales y extrae las noticias nuevas.
+  3. El módulo de clasificación asigna la categoría IPTC de primer nivel.
+  4. Cuando una noticia coincide con los descriptores, se genera una notificación con el formato definido en RF11/RF12.
+  5. La notificación se entrega al buzón interno o al correo del usuario, según la configuración de la alerta.
+
+### CU-04 — Gestión de fuentes RSS
+
+- **Actor primario:** Usuario con rol *Gestor*.
+- **Requisitos relacionados:** RF13, RF14.
+- **Flujo principal:**
+  1. El gestor da de alta un nuevo canal RSS asociándolo a un medio y a una categoría IPTC.
+  2. El sistema valida la URL y normaliza el feed.
+  3. El canal queda disponible para ser asignado a futuras alertas.
+- **Nota:** El sistema arranca con un seed automático de ≥100 canales de ≥10 medios cubriendo todas las categorías IPTC de primer nivel (RF14).
+
+### CU-05 — Consulta del panel de mando
+
+- **Actor primario:** Usuario autenticado (*Gestor* o *Lector*).
+- **Requisitos relacionados:** RF16.
+- **Flujo principal:**
+  1. El usuario accede al panel de mando.
+  2. El sistema muestra nube de palabras y estadísticas agregadas (fuentes, noticias, alertas) y sus desgloses por categoría.
+  3. El *Lector* puede consultar pero no editar alertas ni fuentes; el *Gestor* dispone de las acciones CRUD correspondientes.
+  4. El usuario puede conmutar el idioma de la UI entre ES y EN.
+
+### CU-06 — Evaluación automatizada del proyecto
+
+- **Actor primario:** Evaluador externo.
+- **Requisitos relacionados:** RNF04, RNF05, RNF06, RNF07, RNF09, RNF10.
+- **Precondición:** Docker Desktop instalado.
+- **Flujo principal:**
+  1. El evaluador clona la release y ejecuta `make evaluate` (o `bash evaluate.sh`).
+  2. El script reconstruye imágenes, levanta el stack completo con `docker compose`, espera a que los servicios respondan y ejecuta `pytest --cov`.
+  3. Al finalizar se publican las URLs de frontend, API y Swagger, junto con el informe HTML de cobertura.
+
+---
+
+## 5. Trazabilidad
+
+La trazabilidad entre requisitos, ADRs y componentes se mantiene de forma cruzada:
+
+| Requisito        | ADRs principales                                                                 | Componente / Módulo                                    |
+|------------------|----------------------------------------------------------------------------------|--------------------------------------------------------|
+| RF01, RF08       | [[ADR-014-gestion-alertas]], [[ADR-018-resiliencia-scheduler-y-ciclo-vida]], [[ADR-022-clasificacion-noticias]] | `app/services/agents/alert_monitor_agent.py`           |
+| RF04, RF08       | [[ADR-012-clasificacion-iptc]]                                                   | `app/services/workflows/classification_workflow.py`    |
+| RF05, RF06       | [[ADR-016-gestion-acciones-recomendaciones]]                                     | `newsradar_ui/src/components/AlertForm.tsx`            |
+| RF13, RF14       | [[ADR-008-seed-datos-rss]]                                                       | `app/services/rss_service.py`, `rss_seed.json`         |
+| RF15             | [[ADR-006-api-rest-usuarios]], [[ADR-020-recuperacion-contrasena]], [[ADR-021-sistema-de-verificacion-de-cuenta-por-email-24h]] | `app/services/user_service.py`                         |
+| RF16             | [[ADR-010-arquitectura-frontend]], [[ADR-027-internacionalizacion-i18n]]         | `newsradar_ui/src/pages/Dashboard.tsx`                 |
+| RNF01            | [[ADR-001-arquitectura-5-capas]]                                                 | Estructura global                                      |
+| RNF02, RNF03     | [[ADR-024-fastapi]]                                                              | `app/api/routes/*`                                     |
+| RNF04, RNF09     | [[ADR-002-docker]], [[ADR-017-estrategia-empaquetado-docker]]                    | `docker-compose.yml`, Dockerfiles                      |
+| RNF06, RNF08     | [[ADR-003-ci-actions]], [[ADR-007-sonarcloud]]                                   | `.github/workflows/`                                   |
+| RNF10            | [[ADR-026-automatizacion-evaluacion-y-entregas]]                                 | `evaluate.sh`, `Makefile`                              |
+| RNF11            | [[ADR-004-mkdocs]]                                                               | `mkdocs.yml`, `docs/`                                  |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,50 +1,162 @@
-# 1. Información General del Sitio
-site_name: NEWSRADAR
-site_description: Documentación técnica y de requisitos del proyecto DevOps-gr84-A
-site_author: Equipo DevOps-gr84-A
-use_directory_urls: false
+# =============================================================================
+# NEWSRADAR · Configuración de MkDocs
+# Documentación técnica, ADRs y trazabilidad de IA del proyecto DevOps-gr84-A
+# =============================================================================
 
-# 2. Configuración del Tema Visual
+# 1. Información General del Sitio
+site_name: NEWSRADAR · Documentación Técnica
+site_description: Documentación técnica, decisiones de arquitectura (ADRs) y trazabilidad de prompts de IA del proyecto DevOps-gr84-A.
+site_author: Equipo DevOps-gr84-A
+site_url: https://devopsuc3m-gr84-a.github.io/DevOps-gr84-A/
+repo_url: https://github.com/DevOpsUC3M-gr84-A/DevOps-gr84-A
+repo_name: DevOpsUC3M-gr84-A/DevOps-gr84-A
+edit_uri: edit/main/docs/
+use_directory_urls: false
+copyright: Copyright &copy; 2026 Equipo DevOps-gr84-A · Universidad Carlos III de Madrid
+
+# 2. Configuración del Tema Visual (Material for MkDocs)
 theme:
   name: material
   language: es
+  features:
+    - navigation.instant          # Carga instantánea entre páginas (SPA-like)
+    - navigation.tracking         # Actualiza la URL con la sección visible
+    - navigation.tabs             # Pestañas superiores por sección raíz
+    - navigation.tabs.sticky      # Las pestañas se mantienen visibles al hacer scroll
+    - navigation.sections         # Agrupa secciones en el sidebar
+    - navigation.expand           # Expande el árbol por defecto
+    - navigation.indexes          # Permite "index.md" como portada de sección
+    - navigation.top              # Botón "volver arriba"
+    - toc.follow                  # El sumario sigue el scroll
+    - search.suggest              # Sugerencias mientras escribes
+    - search.highlight            # Resaltado de coincidencias
+    - search.share                # Compartir resultado de búsqueda
+    - content.code.copy           # Botón "copiar" en bloques de código
+    - content.code.annotate       # Anotaciones numeradas en código
+    - content.tabs.link           # Sincroniza pestañas de contenido
+    - content.action.edit         # Botón "editar esta página"
   palette:
-    primary: indigo
-    accent: deep purple
+    # Modo claro
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/weather-night
+        name: Cambiar a modo oscuro
+    # Modo oscuro (slate, profesional)
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/weather-sunny
+        name: Cambiar a modo claro
+  font:
+    text: Inter
+    code: JetBrains Mono
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
 
 # 3. Estructura del Menú de Navegación
+#    NOTA para el equipo: los ADRs nuevos se añaden simplemente como archivo
+#    en `docs/ADRs/`. Después, añade una línea en la sección "Decisiones de
+#    Arquitectura (ADRs)" siguiendo el patrón existente. Si se prefiere un
+#    listado 100% automático, instalar `mkdocs-awesome-pages-plugin` y
+#    reemplazar la lista por un único `.pages` dentro de `docs/ADRs/`.
 nav:
-  - Inicio: index.md
-  - Requisitos: spec.md
-  - Arquitectura (ADRs): 
-    - ADR-001 (5 Capas): ADRs/ADR-001-arquitectura-5-capas.md
-    - ADR-002 (Docker): ADRs/ADR-002-docker.md
-    - ADR-003 (CI Actions): ADRs/ADR-003-ci-actions.md
-    - ADR-004 (MkDocs): ADRs/ADR-004-mkdocs.md
-    - ADR-005 (Estrategia Ramas): ADRs/ADR-005-estrategia-ramas.md
-    - ADR-006 (API REST y Usuarios): ADRs/ADR-006-api-rest-usuarios.md
-    - ADR-007 (SonarCloud): ADRs/ADR-007-sonarcloud.md
-    - ADR-008 (Seed RSS): ADRs/ADR-008-seed-datos-rss.md
-    - ADR-009 (Frontend Stack): ADRs/ADR-009-frontend-stack.md
-    - ADR-010 (Arquitectura Frontend): ADRs/ADR-010-arquitectura-frontend.md
-    - ADR-011 (Frontend Testing): ADRs/ADR-011-frontend-testing.md
-    - ADR-012 (Clasificación IPTC): ADRs/ADR-012-clasificacion-iptc.md
-    - ADR-013 (RBAC Lector): ADRs/ADR-013-rbac-lector.md
-    - ADR-014 (Gestión Alertas): ADRs/ADR-014-gestion-alertas.md
-    - ADR-015 (Migración Elasticsearch): ADRs/ADR-015-migracion-elasticsearch.md
-  - Trazabilidad de IA: prompts.md
+  - 🏠 Inicio / Getting Started: index.md
+  - 🚀 Guía de Arranque (Detallada): quickstart.md
+  - 🏛️ Arquitectura:
+      - Visión General (5 Capas): architecture.md
+      - Despliegue & CI/CD: deployment.md
+  - 📋 Trazabilidad y Requisitos:
+      - Requisitos (RF / RNF): spec.md
+  - 📐 Decisiones de Arquitectura (ADRs):
+      - ADR-001 · Arquitectura 5 Capas: ADRs/ADR-001-arquitectura-5-capas.md
+      - ADR-002 · Docker: ADRs/ADR-002-docker.md
+      - ADR-003 · CI con GitHub Actions: ADRs/ADR-003-ci-actions.md
+      - ADR-004 · MkDocs: ADRs/ADR-004-mkdocs.md
+      - ADR-005 · Estrategia de Ramas: ADRs/ADR-005-estrategia-ramas.md
+      - ADR-006 · API REST y Usuarios: ADRs/ADR-006-api-rest-usuarios.md
+      - ADR-007 · SonarCloud: ADRs/ADR-007-sonarcloud.md
+      - ADR-008 · Seed de Datos RSS: ADRs/ADR-008-seed-datos-rss.md
+      - ADR-009 · Frontend Stack: ADRs/ADR-009-frontend-stack.md
+      - ADR-010 · Arquitectura Frontend: ADRs/ADR-010-arquitectura-frontend.md
+      - ADR-011 · Frontend Testing: ADRs/ADR-011-frontend-testing.md
+      - ADR-012 · Clasificación IPTC: ADRs/ADR-012-clasificacion-iptc.md
+      - ADR-013 · RBAC Lector: ADRs/ADR-013-rbac-lector.md
+      - ADR-014 · Gestión de Alertas: ADRs/ADR-014-gestion-alertas.md
+      - ADR-015 · Migración a Elasticsearch: ADRs/ADR-015-migracion-elasticsearch.md
+      - ADR-016 · Acciones y Recomendaciones: ADRs/ADR-016-gestion-acciones-recomendaciones.md
+      - ADR-017 · Empaquetado Docker: ADRs/ADR-017-estrategia-empaquetado-docker.md
+      - ADR-018 · Resiliencia del Scheduler: ADRs/ADR-018-resiliencia-scheduler-y-ciclo-vida.md
+      - ADR-019 · Notificaciones y .gitignore: ADRs/ADR-019-formateo-notificaciones-y-gitignore.md
+      - ADR-020 · Recuperación de Contraseña: ADRs/ADR-020-recuperacion-contrasena.md
+      - ADR-021 · Verificación de Cuenta 24h: ADRs/ADR-021-sistema-de-verificacion-de-cuenta-por-email-24h.md
+      - ADR-022 · Clasificación de Noticias: ADRs/ADR-022-clasificacion-noticias.md
+      - ADR-023 · Refactor UI & Seguridad: ADRs/ADR-023-refactorizacion-ui-seguridad.md
+      - ADR-024 · FastAPI: ADRs/ADR-024-fastapi.md
+      - ADR-025 · PostgreSQL: ADRs/ADR-025-postgresql.md
+      - ADR-026 · Automatización de Evaluación: ADRs/ADR-026-automatizacion-evaluacion-y-entregas.md
+      - ADR-027 · Internacionalización (i18n): ADRs/ADR-027-internacionalizacion-i18n.md
+  - 🤖 Registro de Prompts de IA: prompts.md
 
 # 4. Plugins
 plugins:
-  - search
+  - search:
+      lang:
+        - es
+        - en
 
 # 5. Extensiones Markdown Avanzadas
 markdown_extensions:
-  - admonition
+  # Estructura y semántica
+  - admonition                 # Bloques !!! note / warning / tip
+  - attr_list                  # Atributos HTML en Markdown
+  - md_in_html                 # Markdown dentro de HTML
+  - def_list                   # Listas de definición
+  - footnotes                  # Notas al pie
+  - tables                     # Tablas extendidas
+  - toc:
+      permalink: true          # Enlace ancla en cada heading
+      permalink_title: Enlace permanente a esta sección
+      toc_depth: 4
+
+  # Familia PyMdown (resaltado, fences, tabs, tareas...)
   - pymdownx.highlight:
       anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
   - pymdownx.inlinehilite
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.details
+  - pymdownx.caret
+  - pymdownx.tilde
+  - pymdownx.mark
+  - pymdownx.keys
+  - pymdownx.smartsymbols
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.snippets:
       check_paths: true
       base_path: docs
+
+# 6. Enlaces sociales / pie de página
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/DevOpsUC3M-gr84-A/DevOps-gr84-A
+      name: Repositorio en GitHub
+  generator: false


### PR DESCRIPTION
## 🎯 Descripción
Relates to #95. Se ha reestructurado por completo la documentación técnica del proyecto utilizando el tema Material for MkDocs. Ahora contamos con un portal profesional, hipervínculos cruzados funcionando y matrices de trazabilidad para garantizar la máxima nota en la evaluación.

## ✨ Cambios principales
* **`mkdocs.yml`**: Migrado a Material theme (con modo claro/oscuro), plugins de búsqueda y navegación jerárquica corregida (27 ADRs listados).
* **Guía de Evaluación (`index.md`)**: Añadida una "Alfombra Roja" para el evaluador con el comando exacto (`bash evaluate.sh`) y tabla de endpoints.
* **Documento Maestro (`spec.md`)**: Consolidación del CSV de requisitos en tablas Markdown limpias con **Matriz de Trazabilidad** (RF/RNF ↔ ADRs ↔ Componentes).
* **Estandarización de ADRs**: Creada la plantilla `docs/ADRs/_TEMPLATE.md`. Se ha corregido el ADR-016 y resuelto el conflicto de numeración (ADR-024 de i18n renombrado a ADR-027).
* **Trazabilidad de IA (`prompts.md`)**: Creada la tabla definitiva para cumplir con el RNF11.

## 🛠️ Instrucciones para el equipo (¡Importante!)
A partir de ahora, nuestra documentación es *Plug & Play*:
1. **Para nuevos ADRs**: Copiad el archivo `_TEMPLATE.md`, rellenadlo, guardadlo en `docs/ADRs/` y añadid una línea al `mkdocs.yml`.
2. **Para uso de IA (ChatGPT, Claude, Copilot)**: Id a `docs/prompts.md`, copiad la fila de la "Plantilla de Copy-Paste" y pegad vuestro historial ahí. ¡Es obligatorio para aprobar el RNF11!

Podéis previsualizar lo guapo que ha quedado bajando la rama y ejecutando:
`pip install mkdocs-material` seguido de `mkdocs serve`.